### PR TITLE
Feature/add coverage ignore

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -155,7 +155,7 @@ jobs:
           # Extract total coverage, e.g. "total: (statements) 82.3%"
           total=$(go tool cover -func=coverage.filtered.out | tail -n1 | awk '{print $3}')
           pct=${total%\%}
-          echo "Go coverage (filtered): $pct%"
+          echo "Go coverage: $pct%"
           # numeric comparison; fail if below threshold
           if awk "BEGIN {exit !($pct >= ${MIN_COVERAGE})}"; then
             echo "Coverage OK (>= ${MIN_COVERAGE}%)"

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -69,20 +69,88 @@ jobs:
             echo "coverage.out not found"
             exit 1
           fi
-          # Build the ignore regex from .coverageignore (one pattern per line,
-          # '#' comments and blank lines skipped). Easy to add/remove entries.
+          # Build ignore/negation regexes from .coverageignore. See backend/.coverageignore for details.
           IGNORE_FILE=".coverageignore"
+
+          glob_to_regex() {
+            local pat="$1"
+            case "$pat" in
+              re:*) printf '%s' "${pat#re:}"; return ;;
+            esac
+
+            # Trailing "/" means "this directory, recursively".
+            local trailing_slash=0
+            case "$pat" in */) trailing_slash=1; pat="${pat%/}" ;; esac
+
+            # Leading "/" anchors to the module root; record and strip it.
+            local anchor_root=0
+            case "$pat" in /*) anchor_root=1; pat="${pat#/}" ;; esac
+
+            # Escape regex metachars (., +, (, ), {, }, |, ^, $, [, ], \)
+            # but leave *, ?, / alone — they are expanded next.
+            pat=$(printf '%s' "$pat" | sed -E 's/[].+(){}|^$\\.[]/\\&/g')
+
+            # Expand globs: ** -> .*, * -> [^/]*, ? -> [^/]
+            # Use a placeholder so ** isn't eaten by the * rule.
+            pat=$(printf '%s' "$pat" \
+              | sed -e 's|\*\*|__DOUBLESTAR__|g' \
+                    -e 's|\*|[^/]*|g' \
+                    -e 's|?|[^/]|g' \
+                    -e 's|__DOUBLESTAR__|.*|g')
+
+            local prefix suffix
+            if [ "$anchor_root" -eq 1 ]; then
+              # module root == first path segment in coverage.out
+              prefix='^[^/]+/'
+            else
+              prefix='(^|/)'
+            fi
+            if [ "$trailing_slash" -eq 1 ]; then
+              suffix='(/|$)'
+            else
+              suffix=''
+            fi
+            printf '%s%s%s' "$prefix" "$pat" "$suffix"
+          }
+
+          INCLUDES=()
+          EXCLUDES=()
           if [ -f "$IGNORE_FILE" ]; then
-            IGNORE_PATTERN=$(grep -Ev '^[[:space:]]*(#|$)' "$IGNORE_FILE" | paste -sd '|' -)
-          else
-            IGNORE_PATTERN=""
+            while IFS= read -r raw || [ -n "$raw" ]; do
+              line="${raw#"${raw%%[![:space:]]*}"}"
+              line="${line%"${line##*[![:space:]]}"}"
+              case "$line" in ''|\#*) continue ;; esac
+              if [ "${line#!}" != "$line" ]; then
+                EXCLUDES+=("$(glob_to_regex "${line#!}")")
+              else
+                INCLUDES+=("$(glob_to_regex "$line")")
+              fi
+            done < "$IGNORE_FILE"
           fi
-          # Preserve the "mode:" header line, drop ignored files from the rest
-          if [ -n "$IGNORE_PATTERN" ]; then
-            echo "Ignoring coverage entries matching: $IGNORE_PATTERN"
-            { head -n1 coverage.out; tail -n +2 coverage.out | grep -Ev "$IGNORE_PATTERN"; } > coverage.filtered.out
+
+          join_alt() { local IFS='|'; printf '%s' "$*"; }
+          INCLUDE_RE=""
+          EXCLUDE_RE=""
+          [ "${#INCLUDES[@]}" -gt 0 ] && INCLUDE_RE=$(join_alt "${INCLUDES[@]}")
+          [ "${#EXCLUDES[@]}" -gt 0 ] && EXCLUDE_RE=$(join_alt "${EXCLUDES[@]}")
+
+          echo "Ignore regex:     ${INCLUDE_RE:-<none>}"
+          echo "Re-include regex: ${EXCLUDE_RE:-<none>}"
+
+          # Build coverage.filtered.out: keep "mode:" header; drop lines
+          # matching INCLUDE_RE unless they also match EXCLUDE_RE.
+          head -n1 coverage.out > coverage.filtered.out
+          if [ -n "$INCLUDE_RE" ]; then
+            if [ -n "$EXCLUDE_RE" ]; then
+              tail -n +2 coverage.out \
+                | awk -v inc="$INCLUDE_RE" -v exc="$EXCLUDE_RE" \
+                    '($0 ~ inc) && !($0 ~ exc) { next } { print }' \
+                >> coverage.filtered.out
+            else
+              tail -n +2 coverage.out | grep -Ev "$INCLUDE_RE" >> coverage.filtered.out
+            fi
           else
-            cp coverage.out coverage.filtered.out
+            tail -n +2 coverage.out >> coverage.filtered.out
           fi
           # Extract total coverage, e.g. "total: (statements) 82.3%"
           total=$(go tool cover -func=coverage.filtered.out | tail -n1 | awk '{print $3}')

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -69,10 +69,25 @@ jobs:
             echo "coverage.out not found"
             exit 1
           fi
+          # Build the ignore regex from .coverageignore (one pattern per line,
+          # '#' comments and blank lines skipped). Easy to add/remove entries.
+          IGNORE_FILE=".coverageignore"
+          if [ -f "$IGNORE_FILE" ]; then
+            IGNORE_PATTERN=$(grep -Ev '^[[:space:]]*(#|$)' "$IGNORE_FILE" | paste -sd '|' -)
+          else
+            IGNORE_PATTERN=""
+          fi
+          # Preserve the "mode:" header line, drop ignored files from the rest
+          if [ -n "$IGNORE_PATTERN" ]; then
+            echo "Ignoring coverage entries matching: $IGNORE_PATTERN"
+            { head -n1 coverage.out; tail -n +2 coverage.out | grep -Ev "$IGNORE_PATTERN"; } > coverage.filtered.out
+          else
+            cp coverage.out coverage.filtered.out
+          fi
           # Extract total coverage, e.g. "total: (statements) 82.3%"
-          total=$(go tool cover -func=coverage.out | tail -n1 | awk '{print $3}')
+          total=$(go tool cover -func=coverage.filtered.out | tail -n1 | awk '{print $3}')
           pct=${total%\%}
-          echo "Go coverage: $pct%"
+          echo "Go coverage (filtered): $pct%"
           # numeric comparison; fail if below threshold
           if awk "BEGIN {exit !($pct >= ${MIN_COVERAGE})}"; then
             echo "Coverage OK (>= ${MIN_COVERAGE}%)"

--- a/backend/.coverageignore
+++ b/backend/.coverageignore
@@ -1,36 +1,33 @@
-# Patterns excluded from the coverage percentage gate.
-# One entry per line. Lines starting with '#' and blank lines are ignored.
-# Entries are matched as regular expressions against the file paths that
-# appear in coverage.out (e.g. "rag-backend/internal/handlers/health.go").
+# Patterns excluded from the coverage percentage gate. Syntax is inspired by .gitignore
 #
-# Tips:
-#   - Escape dots in file names:              internal/handlers/health\.go
-#   - Match a whole directory/package:        /cmd/
-#   - Strict match anchored at module root:   ^rag-backend/cmd/
-#   - Match a suffix (e.g. mocks):            _mock\.go$
+# One entry per line. '#' comments and blank lines are ignored.
+# Entries match against file paths as they appear in coverage.out
+# (e.g. rag-backend/internal/handlers/health.go).
 #
-# Notes:
-#   - Patterns are substring regexes (grep -E); they match anywhere in the
-#     path unless you anchor them with ^ or $.
-#   - A leading "/" (e.g. /cmd/) avoids accidental matches inside another
-#     word like "commander/". Use ^rag-backend/<dir>/ when you need to be
-#     sure only the top-level package is matched.
+# Syntax:
+#   path/to/file.go      Literal path — no escaping needed (dots are literal)
+#   dir/                 Ignore an entire directory (recursive)
+#   *                    Matches anything except "/"
+#   **                   Matches anything, including "/"
+#   ?                    Matches a single character (not "/")
+#   /foo/                Leading "/" anchors to the module root
+#   !pattern             Negation — re-include a path matched by an earlier rule
+#   re:<regex>           Escape hatch: use <regex> as a raw ERE regex
 #
 # Examples:
-#   # Files
-#   internal/handlers/health\.go
-#   _mock\.go$
-#
-#   # Whole packages / directories
-#   /cmd/
-#   /internal/mocks/
-#   ^rag-backend/internal/repositories/vectorstore/memory/
+#   internal/handlers/health.go              # a single file
+#   cmd/                                     # a whole directory (recursive)
+#   *_mock.go                                # any *_mock.go, anywhere
+#   internal/**/testdata/                    # testdata dirs at any depth
+#   /cmd/                                    # only the top-level cmd/
+#   !internal/mocks/keep_me.go               # exception to a broader rule above
+#   re:^rag-backend/internal/gen/.*\.pb\.go$ # full regex when you need it
 
 # Entry point — nothing meaningful to test
-cmd/main\.go
+cmd/main.go
 
 # Trivial liveness endpoint
-internal/handlers/health\.go
+internal/handlers/health.go
 
-# Mock files
-_mock\.go$
+# Mock files (anywhere in the tree)
+*_mock.go

--- a/backend/.coverageignore
+++ b/backend/.coverageignore
@@ -1,0 +1,36 @@
+# Patterns excluded from the coverage percentage gate.
+# One entry per line. Lines starting with '#' and blank lines are ignored.
+# Entries are matched as regular expressions against the file paths that
+# appear in coverage.out (e.g. "rag-backend/internal/handlers/health.go").
+#
+# Tips:
+#   - Escape dots in file names:              internal/handlers/health\.go
+#   - Match a whole directory/package:        /cmd/
+#   - Strict match anchored at module root:   ^rag-backend/cmd/
+#   - Match a suffix (e.g. mocks):            _mock\.go$
+#
+# Notes:
+#   - Patterns are substring regexes (grep -E); they match anywhere in the
+#     path unless you anchor them with ^ or $.
+#   - A leading "/" (e.g. /cmd/) avoids accidental matches inside another
+#     word like "commander/". Use ^rag-backend/<dir>/ when you need to be
+#     sure only the top-level package is matched.
+#
+# Examples:
+#   # Files
+#   internal/handlers/health\.go
+#   _mock\.go$
+#
+#   # Whole packages / directories
+#   /cmd/
+#   /internal/mocks/
+#   ^rag-backend/internal/repositories/vectorstore/memory/
+
+# Entry point — nothing meaningful to test
+cmd/main\.go
+
+# Trivial liveness endpoint
+internal/handlers/health\.go
+
+# Mock files
+_mock\.go$


### PR DESCRIPTION
## Summary

Adds a `.coverageignore` mechanism to the Go CI pipeline so files that don't make sense to test (entry points, trivial handlers, mocks, etc.) can be excluded from the coverage gate without lowering the global threshold.

## Changes

- **`backend/.coverageignore`** — new file listing patterns to exclude. Syntax is `.gitignore`-inspired and documented inline:
  - Literal paths (`internal/handlers/health.go`)
  - Directory recursion (`cmd/`)
  - Globs (`*`, `**`, `?`)
  - Root anchoring with leading `/`
  - Negation with `!` to re-include
  - `re:<regex>` escape hatch for raw ERE patterns
  - Initial entries: `cmd/main.go`, `internal/handlers/health.go`, `*_mock.go`
- **`.github/workflows/ci-go.yml`** — the coverage step now:
  1. Reads `.coverageignore` and converts each pattern into a regex (via a small `glob_to_regex` shell function).
  2. Builds `coverage.filtered.out` by stripping matching lines from `coverage.out` (preserving the `mode:` header and honoring `!` negations via `awk`).
  3. Runs `go tool cover -func` against the filtered file and compares against `MIN_COVERAGE`.
  4. Logs the resulting include/exclude regexes for transparency.

The original `coverage.out` is left untouched; only the gate computation uses the filtered version.

## Test plan

- [x] CI run on this branch reports `Go coverage (filtered): N%` and prints the resolved include/exclude regexes
- [x] Coverage percentage is higher than the unfiltered run (since the ignored files contributed 0%)
- [x] Adding/removing an entry in `backend/.coverageignore` changes the reported number as expected
- [ ] Negation works: a `!path` line re-includes a file matched by a broader pattern above it