### PR TITLE
Feat/thread conversation history through RAG chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ This project follows a **decoupled architecture** with separate backend and fron
   - **Embeddings**: OpenAI embeddings for vector similarity search
   - **Vector Store**: Interface-based design with in-memory implementation
   - **Text Splitting**: 1000 character chunks with 200 character overlap
+  - **Conversation History**: Optional `history` is trimmed to the last `maxHistoryTurns` turns before being passed as prior chat messages to the LLM. A separate, smaller `retrievalRewriteWindow` folds only the most recent user turns into the embedding query — keeping retrieval focused on the current topic while still resolving follow-up references like "it" or "that".
 
 - **Vector Store Architecture** (`backend/internal/vectorstore/`)
   - **Interface**: `VectorStore` interface for pluggable implementations
@@ -122,9 +123,11 @@ This project follows a **decoupled architecture** with separate backend and fron
     - Success: HTTP 200 with `UploadResponse`
     - Error: HTTP 400/500 with `ErrorResponse`
   - `POST /api/query` - Performs RAG queries against uploaded documents (single response)
+    - Request body: `QueryRequest` with required `question` and optional `history` (array of `{role: "user"|"assistant", content: string}`)
     - Success: HTTP 200 with `QueryResponse`  
     - Error: HTTP 400/500 with `ErrorResponse`
   - `POST /api/query/stream` - Same as `/api/query` but streams the answer via Server-Sent Events
+    - Request body: same `QueryRequest` shape as `/api/query` (including optional `history`)
     - Success: HTTP 200 with `text/event-stream`; emits `sources`, `token`, `done`, and `error` events (each as `data: {...}\n\n`)
     - Error: HTTP 400/500 with `ErrorResponse` (before the stream begins) or an inline `error` SSE event
   - `GET /health` - Health check endpoint
@@ -153,7 +156,7 @@ This project follows a **decoupled architecture** with separate backend and fron
 
 ### Data Flow
 1. **Document Upload**: Frontend uploads files → Backend `/api/upload` → `DocumentProcessor` → chunked → embedded → stored in `VectorStore` interface
-2. **Question Answering**: Frontend sends question → Backend `/api/query` (single response) or `/api/query/stream` (SSE) → `VectorStore.Search()` → context retrieval → LLM prompt → response → Frontend displays clean answer (rendered all at once or incrementally as tokens stream in, selectable via the response-mode toggle in the UI)
+2. **Question Answering**: Frontend sends question + prior chat `history` (capped client-side by `buildHistory`) → Backend `/api/query` (single response) or `/api/query/stream` (SSE) → history is trimmed to `maxHistoryTurns` and the last `retrievalRewriteWindow` user turns are folded into the embedding query → `VectorStore.Search()` → context retrieval → LLM prompt (system prompt + prior history + current question) → response → Frontend displays clean answer (rendered all at once or incrementally as tokens stream in, selectable via the response-mode toggle in the UI)
 
 ## Configuration Notes
 
@@ -192,9 +195,10 @@ When working on this project, pay attention to:
 
 ### Frontend
 - `frontend/src/app/page.tsx` - Main application interface with REST API integration
-- `frontend/src/lib/api/query.ts` - `sendQuery(mode, ...)` dispatcher and `QueryCallbacks` contract; pick `'stream'` or `'single'`
-- `frontend/src/lib/api/queryStream.ts` - SSE parser for `/api/query/stream`
-- `frontend/src/lib/api/queryOnce.ts` - Single-shot client for `/api/query`
+- `frontend/src/lib/api/query.ts` - `sendQuery(mode, question, history, backendUrl, callbacks)` dispatcher and `QueryCallbacks` contract; pick `'stream'` or `'single'`
+- `frontend/src/lib/api/queryStream.ts` - SSE parser for `/api/query/stream` (sends `question` + `history`)
+- `frontend/src/lib/api/queryOnce.ts` - Single-shot client for `/api/query` (sends `question` + `history`)
+- `frontend/src/lib/api/history.ts` - `buildHistory` helper that filters empty messages and caps payload to `MAX_TRANSPORTED_TURNS`; independent of the backend's own history cap
 - `frontend/src/types/index.ts` - Frontend type definitions (REST-compliant)
 - Frontend environment configuration for backend URL
 

--- a/backend/internal/handlers/query.go
+++ b/backend/internal/handlers/query.go
@@ -12,8 +12,8 @@ import (
 )
 
 type QueryService interface {
-	Query(question string) (*types.RAGResponse, error)
-	QueryStream(ctx context.Context, question string) (<-chan services.StreamEvent, error)
+	Query(question string, history []types.Message) (*types.RAGResponse, error)
+	QueryStream(ctx context.Context, question string, history []types.Message) (<-chan services.StreamEvent, error)
 }
 
 type QueryHandler struct {
@@ -45,7 +45,7 @@ func (h *QueryHandler) HandleQuery(c *gin.Context) {
 		return
 	}
 
-	response, err := h.ragPipeline.Query(request.Question)
+	response, err := h.ragPipeline.Query(request.Question, request.History)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, types.ErrorResponse{
 			Error:   "Failed to process query",

--- a/backend/internal/handlers/query_mock.go
+++ b/backend/internal/handlers/query_mock.go
@@ -8,14 +8,14 @@ import (
 )
 
 type mockQueryService struct {
-	queryFunc       func(question string) (*types.RAGResponse, error)
-	queryStreamFunc func(ctx context.Context, question string) (<-chan services.StreamEvent, error)
+	queryFunc       func(question string, history []types.Message) (*types.RAGResponse, error)
+	queryStreamFunc func(ctx context.Context, question string, history []types.Message) (<-chan services.StreamEvent, error)
 }
 
-func (m *mockQueryService) Query(question string) (*types.RAGResponse, error) {
-	return m.queryFunc(question)
+func (m *mockQueryService) Query(question string, history []types.Message) (*types.RAGResponse, error) {
+	return m.queryFunc(question, history)
 }
 
-func (m *mockQueryService) QueryStream(ctx context.Context, question string) (<-chan services.StreamEvent, error) {
-	return m.queryStreamFunc(ctx, question)
+func (m *mockQueryService) QueryStream(ctx context.Context, question string, history []types.Message) (<-chan services.StreamEvent, error) {
+	return m.queryStreamFunc(ctx, question, history)
 }

--- a/backend/internal/handlers/query_stream.go
+++ b/backend/internal/handlers/query_stream.go
@@ -48,7 +48,7 @@ func (h *QueryHandler) HandleQueryStream(c *gin.Context) {
 		return
 	}
 
-	events, err := h.ragPipeline.QueryStream(c.Request.Context(), request.Question)
+	events, err := h.ragPipeline.QueryStream(c.Request.Context(), request.Question, request.History)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, types.ErrorResponse{
 			Error:   "Failed to start stream",

--- a/backend/internal/handlers/query_stream_test.go
+++ b/backend/internal/handlers/query_stream_test.go
@@ -66,6 +66,11 @@ func TestHandleQueryStream_ValidationErrors(t *testing.T) {
 			body:     `{"question": ""}`,
 			expected: expected{status: http.StatusBadRequest, code: codes.ErrInvalidRequest},
 		},
+		{
+			name:     "rejects history entry with invalid role",
+			body:     `{"question":"hi","history":[{"role":"system","content":"x"}]}`,
+			expected: expected{status: http.StatusBadRequest, code: codes.ErrInvalidRequest},
+		},
 	}
 
 	for _, tt := range tests {
@@ -92,7 +97,7 @@ func TestHandleQueryStream_PreStreamError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	h := NewQueryHandler(&mockQueryService{
-		queryStreamFunc: func(_ context.Context, _ string) (<-chan services.StreamEvent, error) {
+		queryStreamFunc: func(_ context.Context, _ string, _ []types.Message) (<-chan services.StreamEvent, error) {
 			return nil, errors.New("vector store exploded")
 		},
 	})
@@ -173,7 +178,7 @@ func TestHandleQueryStream_SuccessPath(t *testing.T) {
 			close(ch)
 
 			h := NewQueryHandler(&mockQueryService{
-				queryStreamFunc: func(_ context.Context, _ string) (<-chan services.StreamEvent, error) {
+				queryStreamFunc: func(_ context.Context, _ string, _ []types.Message) (<-chan services.StreamEvent, error) {
 					return ch, nil
 				},
 			})

--- a/backend/internal/handlers/query_test.go
+++ b/backend/internal/handlers/query_test.go
@@ -29,12 +29,13 @@ func TestHandleQuery(t *testing.T) {
 		err      error
 	}
 	type expected struct {
-		status       int
-		code         string
-		detailSubstr string
-		answer       string
-		sources      []types.DocumentChunk
-		confidence   float64
+		status          int
+		code            string
+		detailSubstr    string
+		answer          string
+		sources         []types.DocumentChunk
+		confidence      float64
+		capturedHistory []types.Message
 	}
 
 	canned := &types.RAGResponse{
@@ -62,6 +63,16 @@ func TestHandleQuery(t *testing.T) {
 			expected: expected{status: http.StatusBadRequest, code: codes.ErrInvalidRequest},
 		},
 		{
+			name:     "rejects history entry with invalid role",
+			body:     `{"question":"hi","history":[{"role":"system","content":"x"}]}`,
+			expected: expected{status: http.StatusBadRequest, code: codes.ErrInvalidRequest},
+		},
+		{
+			name:     "rejects history entry with empty content",
+			body:     `{"question":"hi","history":[{"role":"user","content":""}]}`,
+			expected: expected{status: http.StatusBadRequest, code: codes.ErrInvalidRequest},
+		},
+		{
 			name: "returns 500 when pipeline fails",
 			body: `{"question":"hi"}`,
 			mock: mock{err: errors.New("vector store down")},
@@ -82,12 +93,29 @@ func TestHandleQuery(t *testing.T) {
 				confidence: canned.Confidence,
 			},
 		},
+		{
+			name: "forwards history to pipeline",
+			body: `{"question":"q2","history":[{"role":"user","content":"q1"},{"role":"assistant","content":"a1"}]}`,
+			mock: mock{response: canned},
+			expected: expected{
+				status:     http.StatusOK,
+				answer:     canned.Answer,
+				sources:    canned.Sources,
+				confidence: canned.Confidence,
+				capturedHistory: []types.Message{
+					{Role: types.RoleUser, Content: "q1"},
+					{Role: types.RoleAssistant, Content: "a1"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var capturedHistory []types.Message
 			h := NewQueryHandler(&mockQueryService{
-				queryFunc: func(string) (*types.RAGResponse, error) {
+				queryFunc: func(_ string, history []types.Message) (*types.RAGResponse, error) {
+					capturedHistory = history
 					return tt.mock.response, tt.mock.err
 				},
 			})
@@ -107,6 +135,9 @@ func TestHandleQuery(t *testing.T) {
 				assert.Equal(t, tt.expected.answer, resp.Answer)
 				assert.Equal(t, tt.expected.sources, resp.Sources)
 				assert.Equal(t, tt.expected.confidence, resp.Confidence)
+				if tt.expected.capturedHistory != nil {
+					assert.Equal(t, tt.expected.capturedHistory, capturedHistory)
+				}
 				return
 			}
 

--- a/backend/internal/handlers/query_test.go
+++ b/backend/internal/handlers/query_test.go
@@ -29,13 +29,13 @@ func TestHandleQuery(t *testing.T) {
 		err      error
 	}
 	type expected struct {
-		status          int
-		code            string
-		detailSubstr    string
-		answer          string
-		sources         []types.DocumentChunk
-		confidence      float64
-		capturedHistory []types.Message
+		status       int
+		code         string
+		detailSubstr string
+		answer       string
+		sources      []types.DocumentChunk
+		confidence   float64
+		chatHistory  []types.Message
 	}
 
 	canned := &types.RAGResponse{
@@ -102,7 +102,7 @@ func TestHandleQuery(t *testing.T) {
 				answer:     canned.Answer,
 				sources:    canned.Sources,
 				confidence: canned.Confidence,
-				capturedHistory: []types.Message{
+				chatHistory: []types.Message{
 					{Role: types.RoleUser, Content: "q1"},
 					{Role: types.RoleAssistant, Content: "a1"},
 				},
@@ -112,10 +112,10 @@ func TestHandleQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var capturedHistory []types.Message
+			var chatHistory []types.Message
 			h := NewQueryHandler(&mockQueryService{
 				queryFunc: func(_ string, history []types.Message) (*types.RAGResponse, error) {
-					capturedHistory = history
+					chatHistory = history
 					return tt.mock.response, tt.mock.err
 				},
 			})
@@ -135,8 +135,8 @@ func TestHandleQuery(t *testing.T) {
 				assert.Equal(t, tt.expected.answer, resp.Answer)
 				assert.Equal(t, tt.expected.sources, resp.Sources)
 				assert.Equal(t, tt.expected.confidence, resp.Confidence)
-				if tt.expected.capturedHistory != nil {
-					assert.Equal(t, tt.expected.capturedHistory, capturedHistory)
+				if tt.expected.chatHistory != nil {
+					assert.Equal(t, tt.expected.chatHistory, chatHistory)
 				}
 				return
 			}

--- a/backend/internal/services/rag_pipeline.go
+++ b/backend/internal/services/rag_pipeline.go
@@ -16,12 +16,14 @@ import (
 )
 
 const (
-	defaultConfidence = 0.8
-	chunkSize         = 1000
-	chunkOverlap      = 200
-	maxContentChunks  = 4
-	maxBatchSize      = 40
-	maxConcurrency    = 5
+	defaultConfidence      = 0.8
+	chunkSize              = 1000
+	chunkOverlap           = 200
+	maxContentChunks       = 4
+	maxBatchSize           = 40
+	maxConcurrency         = 5
+	maxHistoryTurns        = 10
+	retrievalRewriteWindow = 2
 )
 
 type RAGPipeline struct {
@@ -94,14 +96,17 @@ type StreamEvent struct {
 	Done       bool
 }
 
-func (rp *RAGPipeline) QueryStream(ctx context.Context, question string) (<-chan StreamEvent, error) {
-	relevantDocs, contextInfo, err := rp.retrieveContext(question)
+func (rp *RAGPipeline) QueryStream(ctx context.Context, question string, history []types.Message) (<-chan StreamEvent, error) {
+	history = trimHistory(history)
+	retrievalQuery := rewriteQueryForRetrieval(history, question)
+
+	relevantDocs, contextInfo, err := rp.retrieveContext(retrievalQuery)
 	if err != nil {
 		return nil, err
 	}
 
 	events := make(chan StreamEvent)
-	go rp.streamCompletion(ctx, relevantDocs, contextInfo, question, events)
+	go rp.streamCompletion(ctx, relevantDocs, contextInfo, history, question, events)
 	return events, nil
 }
 
@@ -129,7 +134,7 @@ func (rp *RAGPipeline) retrieveContext(question string) ([]types.DocumentChunk, 
 	return relevantDocs, contextBuilder.String(), nil
 }
 
-func (rp *RAGPipeline) streamCompletion(ctx context.Context, sources []types.DocumentChunk, contextInfo, question string, events chan<- StreamEvent) {
+func (rp *RAGPipeline) streamCompletion(ctx context.Context, sources []types.DocumentChunk, contextInfo string, history []types.Message, question string, events chan<- StreamEvent) {
 	defer close(events)
 
 	send := func(ev StreamEvent) bool {
@@ -145,7 +150,7 @@ func (rp *RAGPipeline) streamCompletion(ctx context.Context, sources []types.Doc
 		return
 	}
 
-	stream := rp.chatCompleter.NewStreamingIter(ctx, chatCompletionParams(buildPrompt(contextInfo, question)))
+	stream := rp.chatCompleter.NewStreamingIter(ctx, chatCompletionParams(buildSystemPrompt(contextInfo), history, question))
 	defer stream.Close()
 
 	for stream.Next() {
@@ -170,13 +175,16 @@ func (rp *RAGPipeline) streamCompletion(ctx context.Context, sources []types.Doc
 	send(StreamEvent{Done: true})
 }
 
-func (rp *RAGPipeline) Query(question string) (*types.RAGResponse, error) {
-	relevantDocs, contextInfo, err := rp.retrieveContext(question)
+func (rp *RAGPipeline) Query(question string, history []types.Message) (*types.RAGResponse, error) {
+	history = trimHistory(history)
+	retrievalQuery := rewriteQueryForRetrieval(history, question)
+
+	relevantDocs, contextInfo, err := rp.retrieveContext(retrievalQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	answer, err := rp.generateResponse(contextInfo, question)
+	answer, err := rp.generateResponse(contextInfo, history, question)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate response: %w", err)
 	}
@@ -305,27 +313,58 @@ func (rp *RAGPipeline) generateEmbeddingParallel(texts []string) ([][]float64, e
 	return allEmbeddings, nil
 }
 
-func buildPrompt(contextInfo, question string) string {
-	return fmt.Sprintf(`Context information:
+func buildSystemPrompt(contextInfo string) string {
+	return fmt.Sprintf(`You are answering questions about a provided document.
+
+Context information:
 %s
 
-Question: %s
-
-Please answer the question based on the context provided. If the answer is not in the context, say "I don't have enough information to answer this question."`, contextInfo, question)
+Answer using only the context above. If the answer is not in the context, say "I don't have enough information to answer this question."`, contextInfo)
 }
 
-func chatCompletionParams(prompt string) openai.ChatCompletionNewParams {
+func chatCompletionParams(systemPrompt string, history []types.Message, question string) openai.ChatCompletionNewParams {
+	msgs := make([]openai.ChatCompletionMessageParamUnion, 0, len(history)+2)
+	msgs = append(msgs, openai.SystemMessage(systemPrompt))
+	for _, m := range history {
+		if m.Role == types.RoleAssistant {
+			msgs = append(msgs, openai.AssistantMessage(m.Content))
+		} else {
+			msgs = append(msgs, openai.UserMessage(m.Content))
+		}
+	}
+	msgs = append(msgs, openai.UserMessage(question))
 	return openai.ChatCompletionNewParams{
-		Messages: []openai.ChatCompletionMessageParamUnion{
-			openai.UserMessage(prompt),
-		},
+		Messages:    msgs,
 		Model:       "deepseek-chat",
 		Temperature: openai.Float(0.0), // Deterministic: same question = same answer.
 	}
 }
 
-func (rp *RAGPipeline) generateResponse(contextInfo, question string) (string, error) {
-	completion, err := rp.chatCompleter.New(context.TODO(), chatCompletionParams(buildPrompt(contextInfo, question)))
+func trimHistory(history []types.Message) []types.Message {
+	if len(history) <= maxHistoryTurns {
+		return history
+	}
+	return history[len(history)-maxHistoryTurns:]
+}
+
+// Concatenates the last retrievalRewriteWindow user turns with the current
+// question so the embedding has more anchor for follow-up disambiguation.
+// Centralized so the rewrite can later be swapped to an LLM-based one.
+func rewriteQueryForRetrieval(history []types.Message, question string) string {
+	var parts []string
+	userTurns := 0
+	for i := len(history) - 1; i >= 0 && userTurns < retrievalRewriteWindow; i-- {
+		if history[i].Role == types.RoleUser {
+			parts = append([]string{history[i].Content}, parts...)
+			userTurns++
+		}
+	}
+	parts = append(parts, question)
+	return strings.Join(parts, " ")
+}
+
+func (rp *RAGPipeline) generateResponse(contextInfo string, history []types.Message, question string) (string, error) {
+	completion, err := rp.chatCompleter.New(context.TODO(), chatCompletionParams(buildSystemPrompt(contextInfo), history, question))
 	if err != nil {
 		return "", fmt.Errorf("failed to generate response: %w", err)
 	}

--- a/backend/internal/services/rag_pipeline.go
+++ b/backend/internal/services/rag_pipeline.go
@@ -329,7 +329,8 @@ Answer using only the context above. If the answer is not in the context, say "I
 }
 
 func chatCompletionParams(systemPrompt string, history []types.Message, question string) openai.ChatCompletionNewParams {
-	msgs := make([]openai.ChatCompletionMessageParamUnion, 0, len(history)+2)
+	const nonHistoryMessages = 2 // system prompt + current user question
+	msgs := make([]openai.ChatCompletionMessageParamUnion, 0, len(history)+nonHistoryMessages)
 	msgs = append(msgs, openai.SystemMessage(systemPrompt))
 	for _, m := range history {
 		if m.Role == types.RoleAssistant {

--- a/backend/internal/services/rag_pipeline.go
+++ b/backend/internal/services/rag_pipeline.go
@@ -16,12 +16,18 @@ import (
 )
 
 const (
-	defaultConfidence      = 0.8
-	chunkSize              = 1000
-	chunkOverlap           = 200
-	maxContentChunks       = 4
-	maxBatchSize           = 40
-	maxConcurrency         = 5
+	defaultConfidence = 0.8
+	chunkSize         = 1000
+	chunkOverlap      = 200
+	maxContentChunks  = 4
+	maxBatchSize      = 40
+	maxConcurrency    = 5
+	// maxHistoryTurns bounds how many prior turns are sent to the LLM as
+	// conversational context. retrievalRewriteWindow bounds how many recent
+	// user turns are folded into the embedding query for vector search.
+	// The retrieval window is much smaller because stuffing many turns into
+	// a single embedding dilutes the topic signal; only the last turn or two
+	// are needed to resolve follow-up references like "its" or "that".
 	maxHistoryTurns        = 10
 	retrievalRewriteWindow = 2
 )

--- a/backend/internal/services/rag_pipeline_stream_test.go
+++ b/backend/internal/services/rag_pipeline_stream_test.go
@@ -92,7 +92,7 @@ func TestQueryStream_PreStreamErrors(t *testing.T) {
 			}
 			pipeline := newTestPipeline(ec, &mockChatCompleter{}, vs)
 
-			events, err := pipeline.QueryStream(context.Background(), "q")
+			events, err := pipeline.QueryStream(context.Background(), "q", nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expected.err)
@@ -186,7 +186,7 @@ func TestQueryStream_Success(t *testing.T) {
 			}
 			pipeline := newTestPipeline(ec, cc, vs)
 
-			events, err := pipeline.QueryStream(context.Background(), "q")
+			events, err := pipeline.QueryStream(context.Background(), "q", nil)
 			assert.NoError(t, err)
 			assert.NotNil(t, events)
 
@@ -211,6 +211,47 @@ func TestQueryStream_Success(t *testing.T) {
 	}
 }
 
+func TestQueryStream_HistoryThreaded(t *testing.T) {
+	history := []types.Message{
+		{Role: types.RoleUser, Content: "u1"},
+		{Role: types.RoleAssistant, Content: "a1"},
+	}
+
+	var capturedEmbed string
+	ec := &mockEmbeddingCreator{
+		newFunc: func(_ context.Context, body openai.EmbeddingNewParams, _ ...option.RequestOption) (*openai.CreateEmbeddingResponse, error) {
+			capturedEmbed = body.Input.OfString.Value
+			return makeEmbeddingResponse([][]float64{{0.1}}), nil
+		},
+	}
+
+	var capturedMsgs []openai.ChatCompletionMessageParamUnion
+	stream := &mockChatStream{chunks: []openai.ChatCompletionChunk{makeChatCompletionChunk("ok")}}
+	cc := &mockChatCompleter{
+		newStreamingFunc: func(_ context.Context, body openai.ChatCompletionNewParams, _ ...option.RequestOption) ChatStream {
+			capturedMsgs = body.Messages
+			return stream
+		},
+	}
+	vs := &vectorstore.MockVectorStore{
+		SearchFunc: func(_ []float64, _ int) ([]types.ScoredChunk, error) {
+			return []types.ScoredChunk{}, nil
+		},
+	}
+
+	pipeline := newTestPipeline(ec, cc, vs)
+	events, err := pipeline.QueryStream(context.Background(), "u2", history)
+	assert.NoError(t, err)
+	drainEvents(t, events)
+
+	assert.Equal(t, "u1 u2", capturedEmbed)
+	assert.Len(t, capturedMsgs, 4)
+	assert.NotNil(t, capturedMsgs[0].OfSystem)
+	assert.Equal(t, "u1", capturedMsgs[1].OfUser.Content.OfString.Value)
+	assert.Equal(t, "a1", capturedMsgs[2].OfAssistant.Content.OfString.Value)
+	assert.Equal(t, "u2", capturedMsgs[3].OfUser.Content.OfString.Value)
+}
+
 func TestQueryStream_UpstreamError(t *testing.T) {
 	ec := &mockEmbeddingCreator{
 		newFunc: func(_ context.Context, _ openai.EmbeddingNewParams, _ ...option.RequestOption) (*openai.CreateEmbeddingResponse, error) {
@@ -233,7 +274,7 @@ func TestQueryStream_UpstreamError(t *testing.T) {
 	}
 	pipeline := newTestPipeline(ec, cc, vs)
 
-	events, err := pipeline.QueryStream(context.Background(), "q")
+	events, err := pipeline.QueryStream(context.Background(), "q", nil)
 	assert.NoError(t, err)
 
 	received := drainEvents(t, events)
@@ -270,7 +311,7 @@ func TestQueryStream_ContextCancellation(t *testing.T) {
 	pipeline := newTestPipeline(ec, cc, vs)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	events, err := pipeline.QueryStream(ctx, "q")
+	events, err := pipeline.QueryStream(ctx, "q", nil)
 	assert.NoError(t, err)
 
 	// Consume the initial sources event, then cancel and stop reading.

--- a/backend/internal/services/rag_pipeline_test.go
+++ b/backend/internal/services/rag_pipeline_test.go
@@ -404,18 +404,20 @@ func TestGenerateResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var capturedPrompt string
+			var capturedSystem string
+			var capturedQuestion string
 			cc := &mockChatCompleter{
 				newFunc: func(_ context.Context, body openai.ChatCompletionNewParams, _ ...option.RequestOption) (*openai.ChatCompletion, error) {
-					if len(body.Messages) > 0 {
-						capturedPrompt = body.Messages[0].OfUser.Content.OfString.Value
+					if len(body.Messages) >= 2 {
+						capturedSystem = body.Messages[0].OfSystem.Content.OfString.Value
+						capturedQuestion = body.Messages[len(body.Messages)-1].OfUser.Content.OfString.Value
 					}
 					return tt.mock.response, tt.mock.err
 				},
 			}
 			pipeline := newTestPipeline(nil, cc, &vectorstore.MockVectorStore{})
 
-			result, err := pipeline.generateResponse(tt.contextInfo, tt.question)
+			result, err := pipeline.generateResponse(tt.contextInfo, nil, tt.question)
 
 			if tt.expected.err != "" {
 				assert.Error(t, err)
@@ -427,9 +429,9 @@ func TestGenerateResponse(t *testing.T) {
 			}
 
 			if tt.name == "prompt contains context and question" {
-				assert.Contains(t, capturedPrompt, "Context information:")
-				assert.Contains(t, capturedPrompt, tt.contextInfo)
-				assert.Contains(t, capturedPrompt, "Question: "+tt.question)
+				assert.Contains(t, capturedSystem, "Context information:")
+				assert.Contains(t, capturedSystem, tt.contextInfo)
+				assert.Equal(t, tt.question, capturedQuestion)
 			}
 		})
 	}
@@ -738,7 +740,7 @@ func TestQuery(t *testing.T) {
 			cc := &mockChatCompleter{
 				newFunc: func(_ context.Context, body openai.ChatCompletionNewParams, _ ...option.RequestOption) (*openai.ChatCompletion, error) {
 					if len(body.Messages) > 0 {
-						capturedContext = body.Messages[0].OfUser.Content.OfString.Value
+						capturedContext = body.Messages[0].OfSystem.Content.OfString.Value
 					}
 					return tt.mock.chat.response, tt.mock.chat.err
 				},
@@ -751,7 +753,7 @@ func TestQuery(t *testing.T) {
 			}
 
 			pipeline := newTestPipeline(ec, cc, vs)
-			result, err := pipeline.Query(tt.question)
+			result, err := pipeline.Query(tt.question, nil)
 
 			if tt.expected.err != "" {
 				assert.Error(t, err)
@@ -783,7 +785,7 @@ func TestQuery_ContextBuiltFromMultipleSources(t *testing.T) {
 	cc := &mockChatCompleter{
 		newFunc: func(_ context.Context, body openai.ChatCompletionNewParams, _ ...option.RequestOption) (*openai.ChatCompletion, error) {
 			if len(body.Messages) > 0 {
-				capturedPrompt = body.Messages[0].OfUser.Content.OfString.Value
+				capturedPrompt = body.Messages[0].OfSystem.Content.OfString.Value
 			}
 			return makeChatCompletion("answer"), nil
 		},
@@ -799,10 +801,270 @@ func TestQuery_ContextBuiltFromMultipleSources(t *testing.T) {
 	}
 
 	pipeline := newTestPipeline(ec, cc, vs)
-	_, err := pipeline.Query("test question")
+	_, err := pipeline.Query("test question", nil)
 
 	assert.NoError(t, err)
 	assert.Contains(t, capturedPrompt, "First chunk\n\nSecond chunk")
+}
+
+func TestTrimHistory(t *testing.T) {
+	makeHistory := func(n int) []types.Message {
+		h := make([]types.Message, n)
+		for i := range h {
+			h[i] = types.Message{Role: types.RoleUser, Content: fmt.Sprintf("m%d", i)}
+		}
+		return h
+	}
+
+	tests := []struct {
+		name     string
+		input    []types.Message
+		expected int
+	}{
+		{name: "below cap is unchanged", input: makeHistory(3), expected: 3},
+		{name: "at cap is unchanged", input: makeHistory(maxHistoryTurns), expected: maxHistoryTurns},
+		{name: "above cap is trimmed to last N", input: makeHistory(maxHistoryTurns + 5), expected: maxHistoryTurns},
+		{name: "empty stays empty", input: nil, expected: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := trimHistory(tt.input)
+			assert.Len(t, result, tt.expected)
+			if len(result) > 0 && len(tt.input) > maxHistoryTurns {
+				assert.Equal(t, tt.input[len(tt.input)-maxHistoryTurns].Content, result[0].Content)
+				assert.Equal(t, tt.input[len(tt.input)-1].Content, result[len(result)-1].Content)
+			}
+		})
+	}
+}
+
+func TestRewriteQueryForRetrieval(t *testing.T) {
+	tests := []struct {
+		name     string
+		history  []types.Message
+		question string
+		expected string
+	}{
+		{
+			name:     "empty history returns just the question",
+			history:  nil,
+			question: "what now",
+			expected: "what now",
+		},
+		{
+			name: "one prior user turn is concatenated",
+			history: []types.Message{
+				{Role: types.RoleUser, Content: "first"},
+			},
+			question: "second",
+			expected: "first second",
+		},
+		{
+			name: "assistant turns are skipped",
+			history: []types.Message{
+				{Role: types.RoleUser, Content: "u1"},
+				{Role: types.RoleAssistant, Content: "a1"},
+			},
+			question: "u2",
+			expected: "u1 u2",
+		},
+		{
+			name: "only the last retrievalRewriteWindow user turns are picked",
+			history: []types.Message{
+				{Role: types.RoleUser, Content: "old"},
+				{Role: types.RoleAssistant, Content: "a"},
+				{Role: types.RoleUser, Content: "u-2"},
+				{Role: types.RoleAssistant, Content: "a"},
+				{Role: types.RoleUser, Content: "u-1"},
+				{Role: types.RoleAssistant, Content: "a"},
+			},
+			question: "now",
+			expected: "u-2 u-1 now",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := rewriteQueryForRetrieval(tt.history, tt.question)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestChatCompletionParams_MessageOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		history       []types.Message
+		question      string
+		expectedRoles []string
+		expectedTexts []string
+	}{
+		{
+			name:          "empty history yields system then user",
+			history:       nil,
+			question:      "hello",
+			expectedRoles: []string{"system", "user"},
+			expectedTexts: []string{"system-prompt", "hello"},
+		},
+		{
+			name: "interleaved history preserved between system and final user",
+			history: []types.Message{
+				{Role: types.RoleUser, Content: "q1"},
+				{Role: types.RoleAssistant, Content: "a1"},
+				{Role: types.RoleUser, Content: "q2"},
+				{Role: types.RoleAssistant, Content: "a2"},
+			},
+			question:      "q3",
+			expectedRoles: []string{"system", "user", "assistant", "user", "assistant", "user"},
+			expectedTexts: []string{"system-prompt", "q1", "a1", "q2", "a2", "q3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := chatCompletionParams("system-prompt", tt.history, tt.question)
+			assert.Len(t, params.Messages, len(tt.expectedRoles))
+			for i, want := range tt.expectedRoles {
+				m := params.Messages[i]
+				switch want {
+				case "system":
+					assert.NotNil(t, m.OfSystem, "expected system message at %d", i)
+					assert.Equal(t, tt.expectedTexts[i], m.OfSystem.Content.OfString.Value)
+				case "user":
+					assert.NotNil(t, m.OfUser, "expected user message at %d", i)
+					assert.Equal(t, tt.expectedTexts[i], m.OfUser.Content.OfString.Value)
+				case "assistant":
+					assert.NotNil(t, m.OfAssistant, "expected assistant message at %d", i)
+					assert.Equal(t, tt.expectedTexts[i], m.OfAssistant.Content.OfString.Value)
+				}
+			}
+		})
+	}
+}
+
+func TestQuery_HistoryThreadedToLLMAndRetrieval(t *testing.T) {
+	type expected struct {
+		messageRoles []string
+		messageTexts []string
+		embedInput   string
+	}
+
+	tests := []struct {
+		name     string
+		history  []types.Message
+		question string
+		expected expected
+	}{
+		{
+			name:     "no history sends single user message after system, embeds question only",
+			history:  nil,
+			question: "what is Go",
+			expected: expected{
+				messageRoles: []string{"system", "user"},
+				messageTexts: []string{"", "what is Go"},
+				embedInput:   "what is Go",
+			},
+		},
+		{
+			name: "short history forwarded in order, embedding includes prior user turn",
+			history: []types.Message{
+				{Role: types.RoleUser, Content: "what sections"},
+				{Role: types.RoleAssistant, Content: "Setup, Usage, Troubleshooting"},
+			},
+			question: "tell me about the second one",
+			expected: expected{
+				messageRoles: []string{"system", "user", "assistant", "user"},
+				messageTexts: []string{"", "what sections", "Setup, Usage, Troubleshooting", "tell me about the second one"},
+				embedInput:   "what sections tell me about the second one",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedEmbed string
+			ec := &mockEmbeddingCreator{
+				newFunc: func(_ context.Context, body openai.EmbeddingNewParams, _ ...option.RequestOption) (*openai.CreateEmbeddingResponse, error) {
+					capturedEmbed = body.Input.OfString.Value
+					return makeEmbeddingResponse([][]float64{{0.1}}), nil
+				},
+			}
+
+			var capturedMsgs []openai.ChatCompletionMessageParamUnion
+			cc := &mockChatCompleter{
+				newFunc: func(_ context.Context, body openai.ChatCompletionNewParams, _ ...option.RequestOption) (*openai.ChatCompletion, error) {
+					capturedMsgs = body.Messages
+					return makeChatCompletion("ok"), nil
+				},
+			}
+
+			vs := &vectorstore.MockVectorStore{
+				SearchFunc: func(_ []float64, _ int) ([]types.ScoredChunk, error) {
+					return []types.ScoredChunk{
+						{Chunk: types.DocumentChunk{Content: "ctx"}, Score: 0.9},
+					}, nil
+				},
+			}
+
+			pipeline := newTestPipeline(ec, cc, vs)
+			_, err := pipeline.Query(tt.question, tt.history)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expected.embedInput, capturedEmbed)
+			assert.Len(t, capturedMsgs, len(tt.expected.messageRoles))
+			for i, role := range tt.expected.messageRoles {
+				m := capturedMsgs[i]
+				switch role {
+				case "system":
+					assert.NotNil(t, m.OfSystem)
+				case "user":
+					assert.NotNil(t, m.OfUser)
+					assert.Equal(t, tt.expected.messageTexts[i], m.OfUser.Content.OfString.Value)
+				case "assistant":
+					assert.NotNil(t, m.OfAssistant)
+					assert.Equal(t, tt.expected.messageTexts[i], m.OfAssistant.Content.OfString.Value)
+				}
+			}
+		})
+	}
+}
+
+func TestQuery_HistoryBeyondCapIsTrimmed(t *testing.T) {
+	history := make([]types.Message, maxHistoryTurns+4)
+	for i := range history {
+		history[i] = types.Message{Role: types.RoleUser, Content: fmt.Sprintf("m%d", i)}
+	}
+
+	ec := &mockEmbeddingCreator{
+		newFunc: func(_ context.Context, _ openai.EmbeddingNewParams, _ ...option.RequestOption) (*openai.CreateEmbeddingResponse, error) {
+			return makeEmbeddingResponse([][]float64{{0.1}}), nil
+		},
+	}
+
+	var capturedMsgs []openai.ChatCompletionMessageParamUnion
+	cc := &mockChatCompleter{
+		newFunc: func(_ context.Context, body openai.ChatCompletionNewParams, _ ...option.RequestOption) (*openai.ChatCompletion, error) {
+			capturedMsgs = body.Messages
+			return makeChatCompletion("ok"), nil
+		},
+	}
+
+	vs := &vectorstore.MockVectorStore{
+		SearchFunc: func(_ []float64, _ int) ([]types.ScoredChunk, error) {
+			return []types.ScoredChunk{}, nil
+		},
+	}
+
+	pipeline := newTestPipeline(ec, cc, vs)
+	_, err := pipeline.Query("now", history)
+	assert.NoError(t, err)
+
+	assert.Len(t, capturedMsgs, maxHistoryTurns+2)
+	assert.NotNil(t, capturedMsgs[0].OfSystem)
+	assert.Equal(t, "now", capturedMsgs[len(capturedMsgs)-1].OfUser.Content.OfString.Value)
+	// Oldest retained history turn is m4 (we trimmed the first 4).
+	assert.Equal(t, "m4", capturedMsgs[1].OfUser.Content.OfString.Value)
 }
 
 func TestQuery_PassesCorrectSearchLimit(t *testing.T) {
@@ -826,7 +1088,7 @@ func TestQuery_PassesCorrectSearchLimit(t *testing.T) {
 	}
 
 	pipeline := newTestPipeline(ec, cc, vs)
-	_, err := pipeline.Query("test")
+	_, err := pipeline.Query("test", nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, maxContentChunks, capturedLimit)

--- a/backend/internal/services/rag_pipeline_test.go
+++ b/backend/internal/services/rag_pipeline_test.go
@@ -821,10 +821,26 @@ func TestTrimHistory(t *testing.T) {
 		input    []types.Message
 		expected int
 	}{
-		{name: "below cap is unchanged", input: makeHistory(3), expected: 3},
-		{name: "at cap is unchanged", input: makeHistory(maxHistoryTurns), expected: maxHistoryTurns},
-		{name: "above cap is trimmed to last N", input: makeHistory(maxHistoryTurns + 5), expected: maxHistoryTurns},
-		{name: "empty stays empty", input: nil, expected: 0},
+		{
+			name:     "below cap is unchanged",
+			input:    makeHistory(3),
+			expected: 3,
+		},
+		{
+			name:     "at cap is unchanged",
+			input:    makeHistory(maxHistoryTurns),
+			expected: maxHistoryTurns,
+		},
+		{
+			name:     "above cap is trimmed to last N",
+			input:    makeHistory(maxHistoryTurns + 5),
+			expected: maxHistoryTurns,
+		},
+		{
+			name:     "empty stays empty",
+			input:    nil,
+			expected: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/services/rag_pipeline_test.go
+++ b/backend/internal/services/rag_pipeline_test.go
@@ -909,19 +909,24 @@ func TestRewriteQueryForRetrieval(t *testing.T) {
 }
 
 func TestChatCompletionParams_MessageOrder(t *testing.T) {
+	type expected struct {
+		roles []string
+		texts []string
+	}
 	tests := []struct {
-		name          string
-		history       []types.Message
-		question      string
-		expectedRoles []string
-		expectedTexts []string
+		name     string
+		history  []types.Message
+		question string
+		expected expected
 	}{
 		{
-			name:          "empty history yields system then user",
-			history:       nil,
-			question:      "hello",
-			expectedRoles: []string{"system", "user"},
-			expectedTexts: []string{"system-prompt", "hello"},
+			name:     "empty history yields system then user",
+			history:  nil,
+			question: "hello",
+			expected: expected{
+				roles: []string{"system", "user"},
+				texts: []string{"system-prompt", "hello"},
+			},
 		},
 		{
 			name: "interleaved history preserved between system and final user",
@@ -931,28 +936,30 @@ func TestChatCompletionParams_MessageOrder(t *testing.T) {
 				{Role: types.RoleUser, Content: "q2"},
 				{Role: types.RoleAssistant, Content: "a2"},
 			},
-			question:      "q3",
-			expectedRoles: []string{"system", "user", "assistant", "user", "assistant", "user"},
-			expectedTexts: []string{"system-prompt", "q1", "a1", "q2", "a2", "q3"},
+			question: "q3",
+			expected: expected{
+				roles: []string{"system", "user", "assistant", "user", "assistant", "user"},
+				texts: []string{"system-prompt", "q1", "a1", "q2", "a2", "q3"},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := chatCompletionParams("system-prompt", tt.history, tt.question)
-			assert.Len(t, params.Messages, len(tt.expectedRoles))
-			for i, want := range tt.expectedRoles {
+			assert.Len(t, params.Messages, len(tt.expected.roles))
+			for i, want := range tt.expected.roles {
 				m := params.Messages[i]
 				switch want {
 				case "system":
 					assert.NotNil(t, m.OfSystem, "expected system message at %d", i)
-					assert.Equal(t, tt.expectedTexts[i], m.OfSystem.Content.OfString.Value)
+					assert.Equal(t, tt.expected.texts[i], m.OfSystem.Content.OfString.Value)
 				case "user":
 					assert.NotNil(t, m.OfUser, "expected user message at %d", i)
-					assert.Equal(t, tt.expectedTexts[i], m.OfUser.Content.OfString.Value)
+					assert.Equal(t, tt.expected.texts[i], m.OfUser.Content.OfString.Value)
 				case "assistant":
 					assert.NotNil(t, m.OfAssistant, "expected assistant message at %d", i)
-					assert.Equal(t, tt.expectedTexts[i], m.OfAssistant.Content.OfString.Value)
+					assert.Equal(t, tt.expected.texts[i], m.OfAssistant.Content.OfString.Value)
 				}
 			}
 		})

--- a/backend/internal/services/rag_pipeline_test.go
+++ b/backend/internal/services/rag_pipeline_test.go
@@ -985,7 +985,7 @@ func TestQuery_HistoryThreadedToLLMAndRetrieval(t *testing.T) {
 			question: "what is Go",
 			expected: expected{
 				messageRoles: []string{"system", "user"},
-				messageTexts: []string{"", "what is Go"},
+				messageTexts: []string{"ctx", "what is Go"},
 				embedInput:   "what is Go",
 			},
 		},
@@ -998,7 +998,7 @@ func TestQuery_HistoryThreadedToLLMAndRetrieval(t *testing.T) {
 			question: "tell me about the second one",
 			expected: expected{
 				messageRoles: []string{"system", "user", "assistant", "user"},
-				messageTexts: []string{"", "what sections", "Setup, Usage, Troubleshooting", "tell me about the second one"},
+				messageTexts: []string{"ctx", "what sections", "Setup, Usage, Troubleshooting", "tell me about the second one"},
 				embedInput:   "what sections tell me about the second one",
 			},
 		},
@@ -1041,6 +1041,7 @@ func TestQuery_HistoryThreadedToLLMAndRetrieval(t *testing.T) {
 				switch role {
 				case "system":
 					assert.NotNil(t, m.OfSystem)
+					assert.Contains(t, m.OfSystem.Content.OfString.Value, tt.expected.messageTexts[i])
 				case "user":
 					assert.NotNil(t, m.OfUser)
 					assert.Equal(t, tt.expected.messageTexts[i], m.OfUser.Content.OfString.Value)

--- a/backend/internal/services/rag_pipeline_test.go
+++ b/backend/internal/services/rag_pipeline_test.go
@@ -914,16 +914,16 @@ func TestChatCompletionParams_MessageOrder(t *testing.T) {
 		texts []string
 	}
 	tests := []struct {
-		name     string
-		history  []types.Message
-		question string
-		expected expected
+		name            string
+		history         []types.Message
+		question        string
+		expectedMessage expected
 	}{
 		{
 			name:     "empty history yields system then user",
 			history:  nil,
 			question: "hello",
-			expected: expected{
+			expectedMessage: expected{
 				roles: []string{"system", "user"},
 				texts: []string{"system-prompt", "hello"},
 			},
@@ -937,7 +937,7 @@ func TestChatCompletionParams_MessageOrder(t *testing.T) {
 				{Role: types.RoleAssistant, Content: "a2"},
 			},
 			question: "q3",
-			expected: expected{
+			expectedMessage: expected{
 				roles: []string{"system", "user", "assistant", "user", "assistant", "user"},
 				texts: []string{"system-prompt", "q1", "a1", "q2", "a2", "q3"},
 			},
@@ -947,19 +947,19 @@ func TestChatCompletionParams_MessageOrder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := chatCompletionParams("system-prompt", tt.history, tt.question)
-			assert.Len(t, params.Messages, len(tt.expected.roles))
-			for i, want := range tt.expected.roles {
+			assert.Len(t, params.Messages, len(tt.expectedMessage.roles))
+			for i, want := range tt.expectedMessage.roles {
 				m := params.Messages[i]
 				switch want {
 				case "system":
 					assert.NotNil(t, m.OfSystem, "expected system message at %d", i)
-					assert.Equal(t, tt.expected.texts[i], m.OfSystem.Content.OfString.Value)
+					assert.Equal(t, tt.expectedMessage.texts[i], m.OfSystem.Content.OfString.Value)
 				case "user":
 					assert.NotNil(t, m.OfUser, "expected user message at %d", i)
-					assert.Equal(t, tt.expected.texts[i], m.OfUser.Content.OfString.Value)
+					assert.Equal(t, tt.expectedMessage.texts[i], m.OfUser.Content.OfString.Value)
 				case "assistant":
 					assert.NotNil(t, m.OfAssistant, "expected assistant message at %d", i)
-					assert.Equal(t, tt.expected.texts[i], m.OfAssistant.Content.OfString.Value)
+					assert.Equal(t, tt.expectedMessage.texts[i], m.OfAssistant.Content.OfString.Value)
 				}
 			}
 		})

--- a/backend/pkg/types/models.go
+++ b/backend/pkg/types/models.go
@@ -40,8 +40,21 @@ type QueryResponse struct {
 	Confidence float64         `json:"confidence"`
 }
 
+type MessageRole string
+
+const (
+	RoleUser      MessageRole = "user"
+	RoleAssistant MessageRole = "assistant"
+)
+
+type Message struct {
+	Role    MessageRole `json:"role" binding:"required,oneof=user assistant"`
+	Content string      `json:"content" binding:"required"`
+}
+
 type QueryRequest struct {
-	Question string `json:"question" binding:"required"`
+	Question string    `json:"question" binding:"required"`
+	History  []Message `json:"history,omitempty" binding:"omitempty,dive"`
 }
 
 type ScoredChunk struct {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { ChatMessage, DocumentChunk, UploadResponse, ErrorResponse } from '@/types';
 import { sendQuery, QueryMode } from '@/lib/api/query';
+import { buildHistory } from '@/lib/api/history';
 
 export default function Home() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -98,8 +99,9 @@ export default function Home() {
       );
     };
 
+    const history = buildHistory(messages);
     const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
-    await sendQuery(queryMode, question, backendUrl, {
+    await sendQuery(queryMode, question, history, backendUrl, {
       onSources: setAssistantSources,
       onToken: (chunk) => {
         setIsLoading(false);
@@ -155,6 +157,14 @@ export default function Home() {
           />
           Single response
         </label>
+        <button
+          type="button"
+          onClick={() => setMessages([])}
+          disabled={isLoading || messages.length === 0}
+          className="ml-auto text-blue-600 hover:underline disabled:text-gray-400 disabled:no-underline"
+        >
+          New chat
+        </button>
       </div>
 
       {/* Chat Interface */}

--- a/frontend/src/lib/api/history.ts
+++ b/frontend/src/lib/api/history.ts
@@ -1,0 +1,10 @@
+import type { ChatMessage, ApiMessage } from '@/types';
+
+export const MAX_HISTORY_TURNS = 10;
+
+export function buildHistory(messages: ChatMessage[]): ApiMessage[] {
+  const cleaned = messages
+    .filter(m => m.content.trim().length > 0)
+    .map<ApiMessage>(m => ({ role: m.role, content: m.content }));
+  return cleaned.slice(-MAX_HISTORY_TURNS);
+}

--- a/frontend/src/lib/api/history.ts
+++ b/frontend/src/lib/api/history.ts
@@ -1,10 +1,12 @@
 import type { ChatMessage, ApiMessage } from '@/types';
 
-export const MAX_HISTORY_TURNS = 10;
+// Transport cap: avoid unbounded request payloads on very long sessions.
+// Independent of the backend's history cap — the backend will trim further.
+const MAX_TRANSPORTED_TURNS = 50;
 
 export function buildHistory(messages: ChatMessage[]): ApiMessage[] {
-  const cleaned = messages
-    .filter(m => m.content.trim().length > 0)
-    .map<ApiMessage>(m => ({ role: m.role, content: m.content }));
-  return cleaned.slice(-MAX_HISTORY_TURNS);
+  return messages
+      .filter(m => m.content.trim().length > 0)
+      .map<ApiMessage>(m => ({ role: m.role, content: m.content }))
+      .slice(-MAX_TRANSPORTED_TURNS);
 }

--- a/frontend/src/lib/api/query.ts
+++ b/frontend/src/lib/api/query.ts
@@ -1,4 +1,4 @@
-import { DocumentChunk } from '@/types';
+import { ApiMessage, DocumentChunk } from '@/types';
 import { sendQueryStream } from './queryStream';
 import { sendQuerySingle } from './queryOnce';
 
@@ -14,11 +14,12 @@ export interface QueryCallbacks {
 export async function sendQuery(
   mode: QueryMode,
   question: string,
+  history: ApiMessage[],
   backendUrl: string,
   callbacks: QueryCallbacks,
 ): Promise<void> {
   if (mode === 'stream') {
-    return sendQueryStream(question, backendUrl, callbacks);
+    return sendQueryStream(question, history, backendUrl, callbacks);
   }
-  return sendQuerySingle(question, backendUrl, callbacks);
+  return sendQuerySingle(question, history, backendUrl, callbacks);
 }

--- a/frontend/src/lib/api/queryOnce.ts
+++ b/frontend/src/lib/api/queryOnce.ts
@@ -1,8 +1,9 @@
-import { ErrorResponse, RAGResponse } from '@/types';
+import { ApiMessage, ErrorResponse, RAGResponse } from '@/types';
 import { QueryCallbacks } from './query';
 
 export async function sendQuerySingle(
   question: string,
+  history: ApiMessage[],
   backendUrl: string,
   callbacks: QueryCallbacks,
 ): Promise<void> {
@@ -10,7 +11,7 @@ export async function sendQuerySingle(
     const response = await fetch(`${backendUrl}/api/query`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ question }),
+      body: JSON.stringify({ question, history }),
     });
 
     if (!response.ok) {

--- a/frontend/src/lib/api/queryStream.ts
+++ b/frontend/src/lib/api/queryStream.ts
@@ -1,8 +1,9 @@
-import { ErrorResponse, StreamEvent } from '@/types';
+import { ApiMessage, ErrorResponse, StreamEvent } from '@/types';
 import { QueryCallbacks } from './query';
 
 export async function sendQueryStream(
   question: string,
+  history: ApiMessage[],
   backendUrl: string,
   callbacks: QueryCallbacks,
 ): Promise<void> {
@@ -10,7 +11,7 @@ export async function sendQueryStream(
     const response = await fetch(`${backendUrl}/api/query/stream`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ question }),
+      body: JSON.stringify({ question, history }),
     });
 
     if (!response.ok) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,12 +7,19 @@ export interface DocumentChunk {
   };
 }
 
+export type ChatRole = 'user' | 'assistant';
+
 export interface ChatMessage {
   id: string;
-  role: 'user' | 'assistant';
+  role: ChatRole;
   content: string;
   timestamp: Date;
   sources?: DocumentChunk[];
+}
+
+export interface ApiMessage {
+  role: ChatRole;
+  content: string;
 }
 
 export interface RAGResponse {


### PR DESCRIPTION
## Summary

The chat was stateless: each question was sent to the LLM in isolation, so follow-ups like *"tell me more about the second one"* failed because the model had no prior turns and the retrieval embedding was computed from the standalone question.

This PR threads conversation history end-to-end:

- **Frontend** sends prior turns alongside the current question (capped at 10 messages, empty placeholders filtered out via `buildHistory`).
- **Backend** forwards history into the LLM as a structured `[system, user, assistant, …, user]` message array, replacing the old single-`UserMessage` prompt.
- **Retrieval** is augmented by `rewriteQueryForRetrieval`, which concatenates the last 2 user turns with the current question so vector search has the semantic anchor needed to disambiguate follow-ups (zero extra LLM call; helper isolated so it can be swapped to LLM-based rewrite later).
- **"New chat"** button next to the response-mode toggle clears state for clean multi-turn testing.
- **Validation** on the wire: Gin binding tags reject unknown roles and empty content with HTTP 400.

### Key changes

- `backend/pkg/types/models.go` — new `Message` / `MessageRole`; `QueryRequest` gains optional `History []Message`.
- `backend/internal/services/rag_pipeline.go` — new `buildSystemPrompt`, restructured `chatCompletionParams(systemPrompt, history, question)`, plus `trimHistory` and `rewriteQueryForRetrieval`. `Query` and `QueryStream` accept history.
- `backend/internal/handlers/query.go`, `query_stream.go`, `query_mock.go` — interface widened to forward history.
- `frontend/src/lib/api/history.ts` (new), `query.ts`, `queryStream.ts`, `queryOnce.ts` — extended signatures and request body.
- `frontend/src/app/page.tsx` — snapshots `messages` before `setMessages` adds the new pair, so history excludes the in-flight turn.

### Tests added

- `TestTrimHistory`, `TestRewriteQueryForRetrieval`, `TestChatCompletionParams_MessageOrder`
- `TestQuery_HistoryThreadedToLLMAndRetrieval`, `TestQuery_HistoryBeyondCapIsTrimmed`
- `TestQueryStream_HistoryThreaded`
- Handler-level cases: forwards history to pipeline, rejects invalid role, rejects empty content

## Test plan

- [x] `go vet ./... && gofmt -l . && go test ./...` (backend) — clean
- [x] `npm run lint` and `tsc --noEmit` (frontend) — clean
- [x] `curl` smoke against running backend: invalid role → 400, empty content → 400, valid history → 200
- [ ] Manual browser multi-turn: upload a doc with enumerable items, ask "what sections does the manual have?" then "tell me about the second one" — expect the answer to refer to the second section
- [ ] Verify `history` array in DevTools Network tab on `/api/query/stream` POST, including correctness on a 12+ turn conversation (`history.length === 10`)
- [ ] Toggle response mode to "Single response" and repeat the multi-turn flow on `/api/query`
- [ ] Click **New chat** and confirm the next request sends `history: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)