### PR TITLE
refactor: make text splitter boundary-aware and recursive

### DIFF
--- a/backend/pkg/utils/text_splitter.go
+++ b/backend/pkg/utils/text_splitter.go
@@ -17,10 +17,6 @@ func NewTextSplitter(chunkSize, chunkOverlap int) *TextSplitter {
 	}
 }
 
-// separators descends from paragraphs to lines to sentence boundaries to words to
-// characters. The list is ASCII-only: CJK enders such as 。？！ are not included, so
-// CJK text falls through to the character-level fallback. The empty string always
-// matches and guarantees termination.
 var separators = []string{"\n\n", "\n", ". ", "? ", "! ", " ", ""}
 
 // SplitText splits the input text into chunks that respect the separator hierarchy,

--- a/backend/pkg/utils/text_splitter.go
+++ b/backend/pkg/utils/text_splitter.go
@@ -17,28 +17,100 @@ func NewTextSplitter(chunkSize, chunkOverlap int) *TextSplitter {
 	}
 }
 
-// SplitText splits the input text into chunks based on the configured ChunkSize and ChunkOverlap.
+// separators descends from paragraphs to lines to sentence boundaries to words to
+// characters. The list is ASCII-only: CJK enders such as 。？！ are not included, so
+// CJK text falls through to the character-level fallback. The empty string always
+// matches and guarantees termination.
+var separators = []string{"\n\n", "\n", ". ", "? ", "! ", " ", ""}
+
+// SplitText splits the input text into chunks that respect the separator hierarchy,
+// only breaking at a finer level when a piece still exceeds ChunkSize. Every emitted
+// chunk has at most ChunkSize runes.
 func (ts *TextSplitter) SplitText(text string) []string {
-	if utf8.RuneCountInString(text) <= ts.ChunkSize {
+	if ts.ChunkSize < 1 || utf8.RuneCountInString(text) <= ts.ChunkSize {
 		return []string{text}
 	}
 
+	overlap := min(ts.ChunkOverlap, ts.ChunkSize-1)
+	return ts.splitText(text, separators, overlap)
+}
+
+func (ts *TextSplitter) splitText(text string, seps []string, overlap int) []string {
+	sep, rest := pickSeparator(text, seps)
+	pieces := splitKeepSeparator(text, sep)
+
 	var chunks []string
-	runes := []rune(text)
-	start := 0
+	var goodSplits []string
 
-	for start < len(runes) {
-		end := min(start+ts.ChunkSize, len(runes))
-
-		chunk := string(runes[start:end])
-		chunks = append(chunks, strings.TrimSpace(chunk))
-
-		if end >= len(runes) {
-			break
+	for _, piece := range pieces {
+		if utf8.RuneCountInString(piece) <= ts.ChunkSize {
+			goodSplits = append(goodSplits, piece)
+			continue
 		}
 
-		start = max(end-ts.ChunkOverlap, 0)
+		chunks = append(chunks, ts.mergeSplits(goodSplits, overlap)...)
+		goodSplits = nil
+		chunks = append(chunks, ts.splitText(piece, rest, overlap)...)
 	}
 
+	chunks = append(chunks, ts.mergeSplits(goodSplits, overlap)...)
+	return chunks
+}
+
+func pickSeparator(text string, seps []string) (string, []string) {
+	for i, sep := range seps {
+		if sep == "" || strings.Contains(text, sep) {
+			return sep, seps[i+1:]
+		}
+	}
+	return "", nil
+}
+
+func splitKeepSeparator(text, sep string) []string {
+	if sep == "" {
+		runes := []rune(text)
+		pieces := make([]string, 0, len(runes))
+		for _, r := range runes {
+			pieces = append(pieces, string(r))
+		}
+		return pieces
+	}
+
+	parts := strings.Split(text, sep)
+	pieces := make([]string, 0, len(parts))
+	for i, part := range parts {
+		if i < len(parts)-1 {
+			part += sep
+		}
+		if part != "" {
+			pieces = append(pieces, part)
+		}
+	}
+	return pieces
+}
+
+func (ts *TextSplitter) mergeSplits(splits []string, overlap int) []string {
+	var chunks []string
+	var buffer []string
+	total := 0
+
+	for _, split := range splits {
+		length := utf8.RuneCountInString(split)
+		if total+length > ts.ChunkSize && total > 0 {
+			if chunk := strings.TrimSpace(strings.Join(buffer, "")); chunk != "" {
+				chunks = append(chunks, chunk)
+			}
+			for len(buffer) > 0 && (total > overlap || (total+length > ts.ChunkSize && total > 0)) {
+				total -= utf8.RuneCountInString(buffer[0])
+				buffer = buffer[1:]
+			}
+		}
+		buffer = append(buffer, split)
+		total += length
+	}
+
+	if chunk := strings.TrimSpace(strings.Join(buffer, "")); chunk != "" {
+		chunks = append(chunks, chunk)
+	}
 	return chunks
 }

--- a/backend/pkg/utils/text_splitter.go
+++ b/backend/pkg/utils/text_splitter.go
@@ -20,8 +20,9 @@ func NewTextSplitter(chunkSize, chunkOverlap int) *TextSplitter {
 var separators = []string{"\n\n", "\n", ". ", "? ", "! ", " ", ""}
 
 // SplitText splits the input text into chunks that respect the separator hierarchy,
-// only breaking at a finer level when a piece still exceeds ChunkSize. Every emitted
-// chunk has at most ChunkSize runes.
+// only breaking at a finer level when a piece still exceeds ChunkSize. When ChunkSize
+// is at least 1, every emitted chunk has at most ChunkSize runes; a non-positive
+// ChunkSize disables splitting and returns the text unchanged.
 func (ts *TextSplitter) SplitText(text string) []string {
 	if ts.ChunkSize < 1 || utf8.RuneCountInString(text) <= ts.ChunkSize {
 		return []string{text}

--- a/backend/pkg/utils/text_splitter_test.go
+++ b/backend/pkg/utils/text_splitter_test.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -92,6 +94,42 @@ func TestSplitText(t *testing.T) {
 			text:     japaneseText,
 			expected: expected{chunks: []string{japaneseText}},
 		},
+		{
+			name:     "splits on paragraph boundaries before finer separators",
+			splitter: splitter{chunkSize: 6, chunkOverlap: 0},
+			text:     "AAAA\n\nBBBB\n\nCCCC",
+			expected: expected{chunks: []string{"AAAA", "BBBB", "CCCC"}},
+		},
+		{
+			name:     "splits on sentence boundaries keeping the trailing period",
+			splitter: splitter{chunkSize: 15, chunkOverlap: 0},
+			text:     "Alpha is one. Beta is two. Gamma is three.",
+			expected: expected{chunks: []string{"Alpha is one.", "Beta is two.", "Gamma is three."}},
+		},
+		{
+			name:     "snaps overlap to a whole word instead of cutting mid word",
+			splitter: splitter{chunkSize: 16, chunkOverlap: 6},
+			text:     "alpha beta gamma delta",
+			expected: expected{chunks: []string{"alpha beta", "beta gamma delta"}},
+		},
+		{
+			name:     "splits on word boundaries with no overlap",
+			splitter: splitter{chunkSize: 12, chunkOverlap: 0},
+			text:     "alpha beta gamma delta",
+			expected: expected{chunks: []string{"alpha beta", "gamma delta"}},
+		},
+		{
+			name:     "drops empty pieces from leading trailing and duplicate separators",
+			splitter: splitter{chunkSize: 3, chunkOverlap: 0},
+			text:     "\n\n\nA\n\nB\n\n",
+			expected: expected{chunks: []string{"A", "B"}},
+		},
+		{
+			name:     "returns whole text when chunk size is not positive",
+			splitter: splitter{chunkSize: 0, chunkOverlap: 0},
+			text:     "abcdef",
+			expected: expected{chunks: []string{"abcdef"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -102,5 +140,67 @@ func TestSplitText(t *testing.T) {
 
 			assert.Equal(t, tt.expected.chunks, result)
 		})
+	}
+}
+
+func TestSplitTextChunkSizeBound(t *testing.T) {
+	type splitter struct {
+		chunkSize    int
+		chunkOverlap int
+	}
+
+	tests := []struct {
+		name     string
+		splitter splitter
+		text     string
+	}{
+		{
+			name:     "structured document with paragraphs and sentences",
+			splitter: splitter{chunkSize: 1000, chunkOverlap: 200},
+			text:     strings.Repeat("This is a sentence about chunking. It has structure.\n\n", 100),
+		},
+		{
+			name:     "single long token without any separator",
+			splitter: splitter{chunkSize: 1000, chunkOverlap: 200},
+			text:     strings.Repeat("abcdefghij", 250),
+		},
+		{
+			name:     "overlap larger than chunk size still terminates",
+			splitter: splitter{chunkSize: 5, chunkOverlap: 100},
+			text:     "abcdefghij",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := NewTextSplitter(tt.splitter.chunkSize, tt.splitter.chunkOverlap)
+
+			result := ts.SplitText(tt.text)
+
+			assert.NotEmpty(t, result)
+			for _, chunk := range result {
+				assert.LessOrEqual(t, utf8.RuneCountInString(chunk), tt.splitter.chunkSize)
+				assert.NotEmpty(t, chunk)
+			}
+		})
+	}
+}
+
+func TestSplitTextLongTokenReproducesSlidingWindow(t *testing.T) {
+	ts := NewTextSplitter(1000, 200)
+	text := strings.Repeat("abcdefghij", 250)
+
+	result := ts.SplitText(text)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, 1000, utf8.RuneCountInString(result[0]))
+	assert.Equal(t, 1000, utf8.RuneCountInString(result[1]))
+	assert.Equal(t, 900, utf8.RuneCountInString(result[2]))
+
+	for i := 0; i < len(result)-1; i++ {
+		current := []rune(result[i])
+		next := []rune(result[i+1])
+		overlap := string(current[len(current)-200:])
+		assert.Equal(t, overlap, string(next[:200]))
 	}
 }


### PR DESCRIPTION
## Context

Document chunking lived in `backend/pkg/utils/text_splitter.go` as a **blind fixed-size rune sliding window** — it cut every `chunkSize` runes regardless of structure, slicing through the middle of words and sentences. Those ragged chunks are what get embedded and retrieved, which hurts both embedding and answer quality.

This replaces `SplitText` with a **recursive, boundary-aware splitter** in the LangChain `RecursiveCharacterTextSplitter` style.

## What changed

**`text_splitter.go`** — `SplitText` now descends a separator hierarchy (`"\n\n"` → `"\n"` → `". "/"? "/"! "` → `" "` → `""`), only breaking a piece at a finer level when it still exceeds `ChunkSize`:

- **keep-separator (trailing-attach):** the separator stays glued to the end of each preceding piece and merged pieces are joined with `""`, so sentence punctuation is preserved (`"Alpha is one."` keeps its period) and there's no separator-length off-by-one in the merge.
- **overlap snaps to clean boundaries:** the greedy `mergeSplits` retains whole trailing words/sentences as overlap instead of cutting mid-token.
- **rune-based throughout**, and every emitted chunk is guaranteed `≤ ChunkSize` (the `""` base case yields length-1 runes).
- a local `overlap = min(overlap, size-1)` clamp + `size < 1` guard fix a latent infinite loop the old window had when `overlap >= size`.

The `NewTextSplitter(chunkSize, chunkOverlap)` signature, the `SplitText` contract, and the public `ChunkSize`/`ChunkOverlap` fields are unchanged, so the only caller (`rag_pipeline.go ProcessDocument`, 1000/200) and `TestNewTextSplitter` need no changes. The hierarchy is ASCII-only for now; CJK enders (`。？！`) fall through to the character-level fallback — the same behavior the existing Japanese tests already lock in.

**`text_splitter_test.go`** — all 10 original cases stay green unchanged (backward-compatible by construction). Added: paragraph splitting, sentence splitting with retained periods (keep-separator regression guard), whole-word overlap, separator-collapse, degenerate `chunkSize=0`, a chunk-size-bound invariant table (structured doc, long token, `overlap > size`), and an explicit sliding-window-reproduction test.

## Verification

- `go test ./pkg/utils/` — all old + new cases pass
- `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green
- **Retrieval eval gate** (`go test ./internal/services/ -run TestEvalRetrieval`) held and slightly improved: `hit@1=0.722`, `recall@4=0.944` (both unchanged), `mrr 0.815 → 0.819`

Eval thresholds (0.65 / 0.85 / 0.75) left unchanged — metrics held flat-to-better, so they weren't ratcheted blindly. Tightening them is an optional follow-up.

https://claude.ai/code/session_01Gb22WaDb2QJtDWMSywb55j

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gb22WaDb2QJtDWMSywb55j)_