### PR TITLE
feat(backend): attribute PDF page numbers to chunks

### DIFF
--- a/backend/internal/handlers/upload.go
+++ b/backend/internal/handlers/upload.go
@@ -14,12 +14,12 @@ import (
 const maxFileSize = 10 << 20 // 10mb
 
 type DocumentIngester interface {
-	ProcessDocument(content string, metadata map[string]string) ([]types.DocumentChunk, error)
+	ProcessDocument(doc types.ProcessedDocument, metadata map[string]string) ([]types.DocumentChunk, error)
 	AddDocumentToVectorStore(chunks []types.DocumentChunk) error
 }
 
 type FileProcessor interface {
-	ProcessFile(fileHeader *multipart.FileHeader) (string, error)
+	ProcessFile(fileHeader *multipart.FileHeader) (types.ProcessedDocument, error)
 	CreateDocument(content, fileName string) types.Document
 }
 
@@ -53,7 +53,7 @@ func (h *UploadHandler) HandleUpload(c *gin.Context) {
 		return
 	}
 
-	content, err := h.documentProcessor.ProcessFile(fileHeader)
+	processed, err := h.documentProcessor.ProcessFile(fileHeader)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, types.ErrorResponse{
 			Error:   "Failed to process document",
@@ -63,13 +63,13 @@ func (h *UploadHandler) HandleUpload(c *gin.Context) {
 		return
 	}
 
-	document := h.documentProcessor.CreateDocument(content, fileHeader.Filename)
+	document := h.documentProcessor.CreateDocument(processed.NormalizedText, fileHeader.Filename)
 
 	// Process into chunks with embeddings
 	metadata := map[string]string{
 		"source": fileHeader.Filename,
 	}
-	chunks, err := h.ragPipeline.ProcessDocument(content, metadata)
+	chunks, err := h.ragPipeline.ProcessDocument(processed, metadata)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, types.ErrorResponse{
 			Error:   "Failed to process document chunks",

--- a/backend/internal/handlers/upload.go
+++ b/backend/internal/handlers/upload.go
@@ -53,7 +53,7 @@ func (h *UploadHandler) HandleUpload(c *gin.Context) {
 		return
 	}
 
-	processed, err := h.documentProcessor.ProcessFile(fileHeader)
+	content, err := h.documentProcessor.ProcessFile(fileHeader)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, types.ErrorResponse{
 			Error:   "Failed to process document",
@@ -63,13 +63,13 @@ func (h *UploadHandler) HandleUpload(c *gin.Context) {
 		return
 	}
 
-	document := h.documentProcessor.CreateDocument(processed.NormalizedText, fileHeader.Filename)
+	document := h.documentProcessor.CreateDocument(content.NormalizedText, fileHeader.Filename)
 
 	// Process into chunks with embeddings
 	metadata := map[string]string{
 		"source": fileHeader.Filename,
 	}
-	chunks, err := h.ragPipeline.ProcessDocument(processed, metadata)
+	chunks, err := h.ragPipeline.ProcessDocument(content, metadata)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, types.ErrorResponse{
 			Error:   "Failed to process document chunks",

--- a/backend/internal/handlers/upload_mock.go
+++ b/backend/internal/handlers/upload_mock.go
@@ -7,12 +7,12 @@ import (
 )
 
 type mockDocumentIngester struct {
-	processDocumentFunc          func(content string, metadata map[string]string) ([]types.DocumentChunk, error)
+	processDocumentFunc          func(doc types.ProcessedDocument, metadata map[string]string) ([]types.DocumentChunk, error)
 	addDocumentToVectorStoreFunc func(chunks []types.DocumentChunk) error
 }
 
-func (m *mockDocumentIngester) ProcessDocument(content string, metadata map[string]string) ([]types.DocumentChunk, error) {
-	return m.processDocumentFunc(content, metadata)
+func (m *mockDocumentIngester) ProcessDocument(doc types.ProcessedDocument, metadata map[string]string) ([]types.DocumentChunk, error) {
+	return m.processDocumentFunc(doc, metadata)
 }
 
 func (m *mockDocumentIngester) AddDocumentToVectorStore(chunks []types.DocumentChunk) error {
@@ -20,11 +20,11 @@ func (m *mockDocumentIngester) AddDocumentToVectorStore(chunks []types.DocumentC
 }
 
 type mockFileProcessor struct {
-	processFileFunc    func(fileHeader *multipart.FileHeader) (string, error)
+	processFileFunc    func(fileHeader *multipart.FileHeader) (types.ProcessedDocument, error)
 	createDocumentFunc func(content, fileName string) types.Document
 }
 
-func (m *mockFileProcessor) ProcessFile(fileHeader *multipart.FileHeader) (string, error) {
+func (m *mockFileProcessor) ProcessFile(fileHeader *multipart.FileHeader) (types.ProcessedDocument, error) {
 	return m.processFileFunc(fileHeader)
 }
 

--- a/backend/internal/handlers/upload_test.go
+++ b/backend/internal/handlers/upload_test.go
@@ -222,9 +222,9 @@ func TestHandleUpload(t *testing.T) {
 			}
 
 			ingester := &mockDocumentIngester{
-				processDocumentFunc: func(content string, metadata map[string]string) ([]types.DocumentChunk, error) {
+				processDocumentFunc: func(doc types.ProcessedDocument, metadata map[string]string) ([]types.DocumentChunk, error) {
 					got.processDocument++
-					capturedContent = content
+					capturedContent = doc.NormalizedText
 					capturedMetadata = metadata
 					return tt.mock.processDocChunks, tt.mock.processDocErr
 				},
@@ -235,9 +235,9 @@ func TestHandleUpload(t *testing.T) {
 				},
 			}
 			processor := &mockFileProcessor{
-				processFileFunc: func(*multipart.FileHeader) (string, error) {
+				processFileFunc: func(*multipart.FileHeader) (types.ProcessedDocument, error) {
 					got.processFile++
-					return tt.mock.processFileContent, tt.mock.processFileErr
+					return types.ProcessedDocument{NormalizedText: tt.mock.processFileContent}, tt.mock.processFileErr
 				},
 				createDocumentFunc: func(content, fileName string) types.Document {
 					got.createDocument++

--- a/backend/internal/services/document_processor.go
+++ b/backend/internal/services/document_processor.go
@@ -21,16 +21,16 @@ func NewDocumentProcessor() *DocumentProcessor {
 	return &DocumentProcessor{}
 }
 
-func (dp *DocumentProcessor) ProcessFile(fileHeader *multipart.FileHeader) (string, error) {
+func (dp *DocumentProcessor) ProcessFile(fileHeader *multipart.FileHeader) (types.ProcessedDocument, error) {
 	file, err := fileHeader.Open()
 	if err != nil {
-		return "", fmt.Errorf("failed to open file: %w", err)
+		return types.ProcessedDocument{}, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer func() { _ = file.Close() }()
 
 	content, err := io.ReadAll(file)
 	if err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
+		return types.ProcessedDocument{}, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	contentType := fileHeader.Header.Get("Content-Type")
@@ -39,22 +39,22 @@ func (dp *DocumentProcessor) ProcessFile(fileHeader *multipart.FileHeader) (stri
 	case "application/pdf":
 		return dp.processPDF(content)
 	case "text/plain":
-		return string(content), nil
+		return types.ProcessedDocument{NormalizedText: utils.Normalize(string(content))}, nil
 	default:
-		return "", fmt.Errorf("unsupported file type: %s", contentType)
+		return types.ProcessedDocument{}, fmt.Errorf("unsupported file type: %s", contentType)
 	}
 }
 
-func (dp *DocumentProcessor) processPDF(content []byte) (string, error) {
+func (dp *DocumentProcessor) processPDF(content []byte) (types.ProcessedDocument, error) {
 	reader := bytes.NewReader(content)
 
 	pdfReader, err := pdf.NewReader(reader, int64(len(content)))
 	if err != nil {
-		return "", fmt.Errorf("failed to create PDF reader: %w", err)
+		return types.ProcessedDocument{}, fmt.Errorf("failed to create PDF reader: %w", err)
 	}
 
 	numPages := pdfReader.NumPage()
-	pages := make([]string, 0, numPages)
+	pages := make([]types.Page, 0, numPages)
 
 	for i := 1; i <= numPages; i++ {
 		page := pdfReader.Page(i)
@@ -67,15 +67,45 @@ func (dp *DocumentProcessor) processPDF(content []byte) (string, error) {
 			continue // Skip pages that can't be processed
 		}
 
-		pages = append(pages, text)
+		pages = append(pages, types.Page{Number: i, Text: text})
 	}
 
-	text := strings.TrimSpace(utils.StripRepeatedHeadersFooters(pages))
-	if text == "" {
-		return "", fmt.Errorf("no text could be extracted from PDF")
+	processed := buildProcessedDocument(pages)
+	if processed.NormalizedText == "" {
+		return types.ProcessedDocument{}, fmt.Errorf("no text could be extracted from PDF")
 	}
 
-	return text, nil
+	return processed, nil
+}
+
+// buildProcessedDocument strips repeated headers/footers across the page slice,
+// normalizes each surviving page independently, and concatenates them with
+// blank-line page breaks. Normalizing per page keeps the recorded PageSpans
+// exact in the final normalized coordinate space: each span's [Start:End]
+// slice of NormalizedText is precisely that page's normalized text.
+func buildProcessedDocument(pages []types.Page) types.ProcessedDocument {
+	texts := make([]string, 0, len(pages))
+	for _, page := range pages {
+		texts = append(texts, page.Text)
+	}
+	cleaned := utils.StripRepeatedHeadersFooters(texts)
+
+	spans := make([]types.PageSpan, 0, len(cleaned))
+	var b strings.Builder
+	for i, page := range cleaned {
+		normalized := utils.Normalize(page)
+		if normalized == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		start := b.Len()
+		b.WriteString(normalized)
+		spans = append(spans, types.PageSpan{Page: pages[i].Number, Start: start, End: b.Len()})
+	}
+
+	return types.ProcessedDocument{NormalizedText: b.String(), PageSpans: spans}
 }
 
 func (dp *DocumentProcessor) CreateDocument(content, fileName string) types.Document {

--- a/backend/internal/services/document_processor.go
+++ b/backend/internal/services/document_processor.go
@@ -80,9 +80,7 @@ func (dp *DocumentProcessor) processPDF(content []byte) (types.ProcessedDocument
 
 // buildProcessedDocument strips repeated headers/footers across the page slice,
 // normalizes each surviving page independently, and concatenates them with
-// blank-line page breaks. Normalizing per page keeps the recorded PageSpans
-// exact in the final normalized coordinate space: each span's [Start:End]
-// slice of NormalizedText is precisely that page's normalized text.
+// blank-line page breaks.
 func buildProcessedDocument(pages []types.Page) types.ProcessedDocument {
 	cleaned := utils.StripRepeatedHeadersFooters(pages)
 

--- a/backend/internal/services/document_processor.go
+++ b/backend/internal/services/document_processor.go
@@ -84,16 +84,12 @@ func (dp *DocumentProcessor) processPDF(content []byte) (types.ProcessedDocument
 // exact in the final normalized coordinate space: each span's [Start:End]
 // slice of NormalizedText is precisely that page's normalized text.
 func buildProcessedDocument(pages []types.Page) types.ProcessedDocument {
-	texts := make([]string, 0, len(pages))
-	for _, page := range pages {
-		texts = append(texts, page.Text)
-	}
-	cleaned := utils.StripRepeatedHeadersFooters(texts)
+	cleaned := utils.StripRepeatedHeadersFooters(pages)
 
 	spans := make([]types.PageSpan, 0, len(cleaned))
 	var b strings.Builder
-	for i, page := range cleaned {
-		normalized := utils.Normalize(page)
+	for _, page := range cleaned {
+		normalized := utils.Normalize(page.Text)
 		if normalized == "" {
 			continue
 		}
@@ -102,7 +98,7 @@ func buildProcessedDocument(pages []types.Page) types.ProcessedDocument {
 		}
 		start := b.Len()
 		b.WriteString(normalized)
-		spans = append(spans, types.PageSpan{Page: pages[i].Number, Start: start, End: b.Len()})
+		spans = append(spans, types.PageSpan{Page: page.Number, Start: start, End: b.Len()})
 	}
 
 	return types.ProcessedDocument{NormalizedText: b.String(), PageSpans: spans}

--- a/backend/internal/services/document_processor_test.go
+++ b/backend/internal/services/document_processor_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	"rag-backend/pkg/types"
 )
 
 func buildTestPDF(contentStream string) []byte {
@@ -155,13 +157,13 @@ func TestProcessFile(t *testing.T) {
 			if tt.expected.err != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expected.err)
-				assert.Empty(t, result)
+				assert.Empty(t, result.NormalizedText)
 			} else if tt.expected.nonEmpty {
 				assert.NoError(t, err)
-				assert.NotEmpty(t, result)
+				assert.NotEmpty(t, result.NormalizedText)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected.result, result)
+				assert.Equal(t, tt.expected.result, result.NormalizedText)
 			}
 		})
 	}
@@ -209,10 +211,107 @@ func TestProcessPDF(t *testing.T) {
 			if tt.expected.err != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expected.err)
-				assert.Empty(t, result)
+				assert.Empty(t, result.NormalizedText)
 			} else {
 				assert.NoError(t, err)
-				assert.NotEmpty(t, result)
+				assert.NotEmpty(t, result.NormalizedText)
+			}
+		})
+	}
+}
+
+func TestBuildProcessedDocument(t *testing.T) {
+	type expected struct {
+		normalized string
+		spans      []types.PageSpan
+	}
+
+	tests := []struct {
+		name     string
+		pages    []types.Page
+		expected expected
+	}{
+		{
+			name: "multi-page records contiguous spans with running offsets",
+			pages: []types.Page{
+				{Number: 1, Text: "First page content"},
+				{Number: 2, Text: "Second page content"},
+				{Number: 3, Text: "Third page content"},
+			},
+			expected: expected{
+				normalized: "First page content\n\nSecond page content\n\nThird page content",
+				spans: []types.PageSpan{
+					{Page: 1, Start: 0, End: 18},
+					{Page: 2, Start: 20, End: 39},
+					{Page: 3, Start: 41, End: 59},
+				},
+			},
+		},
+		{
+			name: "skips an empty middle page but keeps true page numbers",
+			pages: []types.Page{
+				{Number: 1, Text: "Alpha content here"},
+				{Number: 2, Text: "   "},
+				{Number: 3, Text: "Gamma content here"},
+			},
+			expected: expected{
+				normalized: "Alpha content here\n\nGamma content here",
+				spans: []types.PageSpan{
+					{Page: 1, Start: 0, End: 18},
+					{Page: 3, Start: 20, End: 38},
+				},
+			},
+		},
+		{
+			name:  "single page produces a single span",
+			pages: []types.Page{{Number: 1, Text: "Only page text"}},
+			expected: expected{
+				normalized: "Only page text",
+				spans:      []types.PageSpan{{Page: 1, Start: 0, End: 14}},
+			},
+		},
+		{
+			name: "strips a repeated header before computing spans",
+			pages: []types.Page{
+				{Number: 1, Text: "ACME Confidential\nAlpha body"},
+				{Number: 2, Text: "ACME Confidential\nBeta body"},
+				{Number: 3, Text: "ACME Confidential\nGamma body"},
+			},
+			expected: expected{
+				normalized: "Alpha body\n\nBeta body\n\nGamma body",
+				spans: []types.PageSpan{
+					{Page: 1, Start: 0, End: 10},
+					{Page: 2, Start: 12, End: 21},
+					{Page: 3, Start: 23, End: 33},
+				},
+			},
+		},
+		{
+			name: "all-empty pages yield empty text and no spans",
+			pages: []types.Page{
+				{Number: 1, Text: ""},
+				{Number: 2, Text: ""},
+				{Number: 3, Text: ""},
+			},
+			expected: expected{
+				normalized: "",
+				spans:      []types.PageSpan{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildProcessedDocument(tt.pages)
+
+			assert.Equal(t, tt.expected.normalized, result.NormalizedText)
+			assert.Equal(t, tt.expected.spans, result.PageSpans)
+
+			for _, span := range result.PageSpans {
+				assert.GreaterOrEqual(t, span.Start, 0)
+				assert.LessOrEqual(t, span.End, len(result.NormalizedText))
+				assert.NotEmpty(t, result.NormalizedText[span.Start:span.End],
+					"span for page %d must locate non-empty text", span.Page)
 			}
 		})
 	}

--- a/backend/internal/services/eval_test.go
+++ b/backend/internal/services/eval_test.go
@@ -222,7 +222,8 @@ func TestEvalRetrieval(t *testing.T) {
 			continue
 		}
 		content := loadDocument(t, gc.Document)
-		chunks, err := pipeline.ProcessDocument(content, map[string]string{"source": gc.Document})
+		doc := types.ProcessedDocument{NormalizedText: utils.Normalize(content)}
+		chunks, err := pipeline.ProcessDocument(doc, map[string]string{"source": gc.Document})
 		assert.NoError(t, err)
 		assert.NoError(t, pipeline.AddDocumentToVectorStore(chunks))
 		ingested[gc.Document] = true
@@ -280,7 +281,8 @@ func TestEvalNeighborExpansionRecoversCrossChunkAnswer(t *testing.T) {
 	store := memory.NewMemoryVectorStore()
 	pipeline := newEvalPipeline(embedder, store)
 
-	chunks, err := pipeline.ProcessDocument(content, map[string]string{"source": "physics"})
+	doc := types.ProcessedDocument{NormalizedText: utils.Normalize(content)}
+	chunks, err := pipeline.ProcessDocument(doc, map[string]string{"source": "physics"})
 	assert.NoError(t, err)
 	assert.NoError(t, pipeline.AddDocumentToVectorStore(chunks))
 	assert.Greater(t, len(chunks), maxContentChunks, "need more chunks than k so the answer chunk falls outside top-k")

--- a/backend/internal/services/rag_pipeline.go
+++ b/backend/internal/services/rag_pipeline.go
@@ -122,10 +122,6 @@ func (rp *RAGPipeline) ProcessDocument(doc types.ProcessedDocument, metadata map
 	return chunks, nil
 }
 
-// pageForOffset maps a byte offset in the normalized text to the page whose
-// span contains it, attributing a chunk to the page of its StartOffset. The
-// "\n\n" gap between page spans falls to the preceding page. Returns 0 when
-// the document carries no page spans (e.g. plain-text uploads).
 func pageForOffset(spans []types.PageSpan, offset int) int {
 	if len(spans) == 0 {
 		return 0

--- a/backend/internal/services/rag_pipeline.go
+++ b/backend/internal/services/rag_pipeline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"rag-backend/internal/repositories/vectorstore"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -64,8 +65,8 @@ func NewRAGPipeline(cfg *config.Config, vectorStore vectorstore.VectorStore) *RA
 	}
 }
 
-func (rp *RAGPipeline) ProcessDocument(content string, metadata map[string]string) ([]types.DocumentChunk, error) {
-	normalized := utils.Normalize(content)
+func (rp *RAGPipeline) ProcessDocument(doc types.ProcessedDocument, metadata map[string]string) ([]types.DocumentChunk, error) {
+	normalized := doc.NormalizedText
 	textChunks := rp.textSplitter.SplitText(normalized)
 
 	var embeddings [][]float64
@@ -93,19 +94,49 @@ func (rp *RAGPipeline) ProcessDocument(content string, metadata map[string]strin
 			end = start + len(textChunk)
 			cursor = start + 1
 		}
+		page := pageForOffset(doc.PageSpans, start)
+		chunkMetadata := metadata
+		if page > 0 {
+			chunkMetadata = cloneMetadata(metadata)
+			chunkMetadata["page"] = strconv.Itoa(page)
+		}
 		chunks[i] = types.DocumentChunk{
 			ID:          fmt.Sprintf("%s-chunk-%d", source, i),
 			Content:     textChunk,
 			Embedding:   embeddings[i],
-			Metadata:    metadata,
+			Metadata:    chunkMetadata,
 			Source:      source,
 			ChunkIndex:  i,
 			StartOffset: start,
 			EndOffset:   end,
+			Page:        page,
 		}
 	}
 
 	return chunks, nil
+}
+
+// pageForOffset maps a byte offset in the normalized text to the page whose
+// span contains it, attributing a chunk to the page of its StartOffset. The
+// "\n\n" gap between page spans falls to the preceding page. Returns 0 when
+// the document carries no page spans (e.g. plain-text uploads).
+func pageForOffset(spans []types.PageSpan, offset int) int {
+	if len(spans) == 0 {
+		return 0
+	}
+	i := sort.Search(len(spans), func(i int) bool { return spans[i].Start > offset }) - 1
+	if i < 0 {
+		return 0
+	}
+	return spans[i].Page
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	clone := make(map[string]string, len(metadata)+1)
+	for k, v := range metadata {
+		clone[k] = v
+	}
+	return clone
 }
 
 func (rp *RAGPipeline) AddDocumentToVectorStore(chunks []types.DocumentChunk) error {

--- a/backend/internal/services/rag_pipeline_test.go
+++ b/backend/internal/services/rag_pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -523,7 +524,8 @@ func TestProcessDocument(t *testing.T) {
 			}
 			pipeline := newTestPipeline(ec, nil, &vectorstore.MockVectorStore{})
 
-			chunks, err := pipeline.ProcessDocument(tt.content, tt.metadata)
+			doc := types.ProcessedDocument{NormalizedText: utils.Normalize(tt.content)}
+			chunks, err := pipeline.ProcessDocument(doc, tt.metadata)
 
 			if tt.expected.err != "" {
 				assert.Error(t, err)
@@ -564,7 +566,8 @@ func TestProcessDocument_LargeDocumentUsesParallelPath(t *testing.T) {
 	}
 	pipeline := newTestPipeline(ec, nil, &vectorstore.MockVectorStore{})
 
-	chunks, err := pipeline.ProcessDocument(content, metadata)
+	doc := types.ProcessedDocument{NormalizedText: utils.Normalize(content)}
+	chunks, err := pipeline.ProcessDocument(doc, metadata)
 
 	assert.NoError(t, err)
 	assert.Greater(t, len(chunks), maxBatchSize, "should have more than maxBatchSize chunks to trigger parallel path")
@@ -613,7 +616,8 @@ func TestProcessDocument_CharOffsetsLocateChunksInNormalizedText(t *testing.T) {
 			pipeline := newTestPipeline(ec, nil, &vectorstore.MockVectorStore{})
 
 			normalized := utils.Normalize(tt.content)
-			chunks, err := pipeline.ProcessDocument(tt.content, map[string]string{"source": "doc"})
+			doc := types.ProcessedDocument{NormalizedText: normalized}
+			chunks, err := pipeline.ProcessDocument(doc, map[string]string{"source": "doc"})
 			assert.NoError(t, err)
 
 			if tt.expected.multiChunk {
@@ -629,6 +633,115 @@ func TestProcessDocument_CharOffsetsLocateChunksInNormalizedText(t *testing.T) {
 				assert.Greater(t, chunk.StartOffset, prevStart, "chunk %d start must be strictly monotonic", i)
 				prevStart = chunk.StartOffset
 			}
+		})
+	}
+}
+
+func TestPageForOffset(t *testing.T) {
+	spans := []types.PageSpan{
+		{Page: 1, Start: 0, End: 10},
+		{Page: 2, Start: 12, End: 20},
+		{Page: 3, Start: 22, End: 30},
+	}
+
+	tests := []struct {
+		name     string
+		spans    []types.PageSpan
+		offset   int
+		expected int
+	}{
+		{name: "start of first page", spans: spans, offset: 0, expected: 1},
+		{name: "inside first page", spans: spans, offset: 5, expected: 1},
+		{name: "gap between pages falls to preceding page", spans: spans, offset: 11, expected: 1},
+		{name: "start of second page", spans: spans, offset: 12, expected: 2},
+		{name: "inside third page", spans: spans, offset: 25, expected: 3},
+		{name: "offset past the end maps to last page", spans: spans, offset: 100, expected: 3},
+		{name: "no spans yields zero", spans: nil, offset: 5, expected: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, pageForOffset(tt.spans, tt.offset))
+		})
+	}
+}
+
+func TestProcessDocument_AttributesPageNumbers(t *testing.T) {
+	page1 := strings.TrimSpace(strings.Repeat("alpha ", 300))
+	page2 := strings.TrimSpace(strings.Repeat("beta ", 300))
+	paginated := types.ProcessedDocument{
+		NormalizedText: page1 + "\n\n" + page2,
+		PageSpans: []types.PageSpan{
+			{Page: 1, Start: 0, End: len(page1)},
+			{Page: 2, Start: len(page1) + 2, End: len(page1) + 2 + len(page2)},
+		},
+	}
+
+	type expected struct {
+		paginated bool
+	}
+
+	tests := []struct {
+		name     string
+		doc      types.ProcessedDocument
+		expected expected
+	}{
+		{
+			name:     "paginated document stamps page on each chunk",
+			doc:      paginated,
+			expected: expected{paginated: true},
+		},
+		{
+			name:     "plain-text document leaves chunks unpaginated",
+			doc:      types.ProcessedDocument{NormalizedText: utils.Normalize("a short plain document")},
+			expected: expected{paginated: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ec := &mockEmbeddingCreator{
+				newFunc: func(_ context.Context, body openai.EmbeddingNewParams, _ ...option.RequestOption) (*openai.CreateEmbeddingResponse, error) {
+					n := len(body.Input.OfArrayOfStrings)
+					embeddings := make([][]float64, n)
+					for i := range embeddings {
+						embeddings[i] = []float64{0.1}
+					}
+					return makeEmbeddingResponse(embeddings), nil
+				},
+			}
+			pipeline := newTestPipeline(ec, nil, &vectorstore.MockVectorStore{})
+
+			inputMetadata := map[string]string{"source": "doc"}
+			chunks, err := pipeline.ProcessDocument(tt.doc, inputMetadata)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, chunks)
+
+			_, mutated := inputMetadata["page"]
+			assert.False(t, mutated, "the shared input metadata must not be mutated")
+
+			if !tt.expected.paginated {
+				for i, chunk := range chunks {
+					assert.Equal(t, 0, chunk.Page, "chunk %d should have no page", i)
+					_, ok := chunk.Metadata["page"]
+					assert.False(t, ok, "chunk %d metadata should not carry a page", i)
+				}
+				return
+			}
+
+			assert.Greater(t, len(chunks), 1, "fixture should split into multiple chunks")
+			pagesSeen := map[int]bool{}
+			prevPage := 0
+			for i, chunk := range chunks {
+				assert.Greater(t, chunk.Page, 0, "chunk %d should be attributed to a page", i)
+				assert.Equal(t, strconv.Itoa(chunk.Page), chunk.Metadata["page"], "chunk %d metadata page must match field", i)
+				assert.GreaterOrEqual(t, chunk.Page, prevPage, "page attribution must be non-decreasing")
+				prevPage = chunk.Page
+				pagesSeen[chunk.Page] = true
+			}
+			assert.True(t, pagesSeen[1] && pagesSeen[2], "both pages should be represented across chunks")
+			assert.NotEqual(t, chunks[0].Metadata["page"], chunks[len(chunks)-1].Metadata["page"],
+				"per-chunk metadata must be independent, not a shared map")
 		})
 	}
 }

--- a/backend/pkg/types/models.go
+++ b/backend/pkg/types/models.go
@@ -19,6 +19,23 @@ type DocumentChunk struct {
 	ChunkIndex  int               `json:"chunkIndex"`
 	StartOffset int               `json:"startOffset"`
 	EndOffset   int               `json:"endOffset"`
+	Page        int               `json:"page,omitempty"`
+}
+
+type Page struct {
+	Number int    `json:"number"`
+	Text   string `json:"text"`
+}
+
+type PageSpan struct {
+	Page  int `json:"page"`
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type ProcessedDocument struct {
+	NormalizedText string     `json:"normalizedText"`
+	PageSpans      []PageSpan `json:"pageSpans,omitempty"`
 }
 
 type RAGResponse struct {

--- a/backend/pkg/utils/text_normalizer.go
+++ b/backend/pkg/utils/text_normalizer.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"regexp"
 	"strings"
+
+	"rag-backend/pkg/types"
 )
 
 const (
@@ -41,10 +43,11 @@ func Normalize(text string) string {
 }
 
 // StripRepeatedHeadersFooters removes page headers and footers that repeat
-// across the per-page text of a PDF, returning the surviving per-page text in
-// the same order so callers can keep page boundaries. Detection is skipped for
-// documents with too few pages to provide a reliable signal.
-func StripRepeatedHeadersFooters(pages []string) []string {
+// across the per-page text of a PDF, returning each page with its text cleaned
+// and its Number preserved so page attribution travels with the text rather
+// than relying on positional alignment. Detection is skipped for documents with
+// too few pages to provide a reliable signal.
+func StripRepeatedHeadersFooters(pages []types.Page) []types.Page {
 	if len(pages) < minPagesForDetection {
 		return pages
 	}
@@ -54,7 +57,7 @@ func StripRepeatedHeadersFooters(pages []string) []string {
 	footerCounts := map[string]int{}
 
 	for i, page := range pages {
-		lines := splitLines(page)
+		lines := splitLines(page.Text)
 		pageLines[i] = lines
 
 		for _, line := range topLines(lines, scanLines) {
@@ -77,11 +80,11 @@ func StripRepeatedHeadersFooters(pages []string) []string {
 	headers := frequentSignatures(headerCounts, threshold)
 	footers := frequentSignatures(footerCounts, threshold)
 
-	cleaned := make([]string, 0, len(pages))
-	for _, lines := range pageLines {
+	cleaned := make([]types.Page, 0, len(pages))
+	for i, lines := range pageLines {
 		lines = trimLeadingMatches(lines, headers)
 		lines = trimTrailingMatches(lines, footers)
-		cleaned = append(cleaned, strings.Join(lines, "\n"))
+		cleaned = append(cleaned, types.Page{Number: pages[i].Number, Text: strings.Join(lines, "\n")})
 	}
 
 	return cleaned

--- a/backend/pkg/utils/text_normalizer.go
+++ b/backend/pkg/utils/text_normalizer.go
@@ -43,10 +43,7 @@ func Normalize(text string) string {
 }
 
 // StripRepeatedHeadersFooters removes page headers and footers that repeat
-// across the per-page text of a PDF, returning each page with its text cleaned
-// and its Number preserved so page attribution travels with the text rather
-// than relying on positional alignment. Detection is skipped for documents with
-// too few pages to provide a reliable signal.
+// across the per-page text of a PDF
 func StripRepeatedHeadersFooters(pages []types.Page) []types.Page {
 	if len(pages) < minPagesForDetection {
 		return pages

--- a/backend/pkg/utils/text_normalizer.go
+++ b/backend/pkg/utils/text_normalizer.go
@@ -41,12 +41,12 @@ func Normalize(text string) string {
 }
 
 // StripRepeatedHeadersFooters removes page headers and footers that repeat
-// across the per-page text of a PDF, then joins the surviving pages with blank
-// lines so page breaks become paragraph boundaries. Detection is skipped for
+// across the per-page text of a PDF, returning the surviving per-page text in
+// the same order so callers can keep page boundaries. Detection is skipped for
 // documents with too few pages to provide a reliable signal.
-func StripRepeatedHeadersFooters(pages []string) string {
+func StripRepeatedHeadersFooters(pages []string) []string {
 	if len(pages) < minPagesForDetection {
-		return strings.Join(pages, "\n\n")
+		return pages
 	}
 
 	pageLines := make([][]string, len(pages))
@@ -84,7 +84,7 @@ func StripRepeatedHeadersFooters(pages []string) string {
 		cleaned = append(cleaned, strings.Join(lines, "\n"))
 	}
 
-	return strings.Join(cleaned, "\n\n")
+	return cleaned
 }
 
 func splitLines(page string) []string {

--- a/backend/pkg/utils/text_normalizer_test.go
+++ b/backend/pkg/utils/text_normalizer_test.go
@@ -97,7 +97,7 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 	tests := []struct {
 		name     string
 		pages    []string
-		expected string
+		expected []string
 	}{
 		{
 			name: "strips a repeated header line",
@@ -106,7 +106,7 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 				"ACME Confidential\nBeta body content",
 				"ACME Confidential\nGamma body content",
 			},
-			expected: "Alpha body content\n\nBeta body content\n\nGamma body content",
+			expected: []string{"Alpha body content", "Beta body content", "Gamma body content"},
 		},
 		{
 			name: "strips a repeated footer with varying page numbers",
@@ -115,7 +115,7 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 				"Beta body content\nPage 2",
 				"Gamma body content\nPage 3",
 			},
-			expected: "Alpha body content\n\nBeta body content\n\nGamma body content",
+			expected: []string{"Alpha body content", "Beta body content", "Gamma body content"},
 		},
 		{
 			name: "strips bare page-number footers",
@@ -124,7 +124,7 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 				"Beta body content\n13",
 				"Gamma body content\n14",
 			},
-			expected: "Alpha body content\n\nBeta body content\n\nGamma body content",
+			expected: []string{"Alpha body content", "Beta body content", "Gamma body content"},
 		},
 		{
 			name: "preserves non-repeating first lines",
@@ -133,7 +133,11 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 				"Unique beta title\nBeta body content",
 				"Unique gamma title\nGamma body content",
 			},
-			expected: "Unique alpha title\nAlpha body content\n\nUnique beta title\nBeta body content\n\nUnique gamma title\nGamma body content",
+			expected: []string{
+				"Unique alpha title\nAlpha body content",
+				"Unique beta title\nBeta body content",
+				"Unique gamma title\nGamma body content",
+			},
 		},
 		{
 			name: "keeps identical lines when below minimum page count",
@@ -141,7 +145,10 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 				"Repeated header\nAlpha body content",
 				"Repeated header\nBeta body content",
 			},
-			expected: "Repeated header\nAlpha body content\n\nRepeated header\nBeta body content",
+			expected: []string{
+				"Repeated header\nAlpha body content",
+				"Repeated header\nBeta body content",
+			},
 		},
 		{
 			name: "keeps a line repeated below the threshold",
@@ -151,12 +158,17 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 				"Distinct gamma head\nGamma body content",
 				"Distinct delta head\nDelta body content",
 			},
-			expected: "Shared header\nAlpha body content\n\nDistinct beta head\nBeta body content\n\nDistinct gamma head\nGamma body content\n\nDistinct delta head\nDelta body content",
+			expected: []string{
+				"Shared header\nAlpha body content",
+				"Distinct beta head\nBeta body content",
+				"Distinct gamma head\nGamma body content",
+				"Distinct delta head\nDelta body content",
+			},
 		},
 		{
 			name:     "handles empty pages without panicking",
 			pages:    []string{"", "", ""},
-			expected: "\n\n\n\n",
+			expected: []string{"", "", ""},
 		},
 	}
 

--- a/backend/pkg/utils/text_normalizer_test.go
+++ b/backend/pkg/utils/text_normalizer_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"rag-backend/pkg/types"
 )
 
 func TestNormalize(t *testing.T) {
@@ -174,7 +176,15 @@ func TestStripRepeatedHeadersFooters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, StripRepeatedHeadersFooters(tt.pages))
+			input := make([]types.Page, len(tt.pages))
+			for i, text := range tt.pages {
+				input[i] = types.Page{Number: i + 1, Text: text}
+			}
+			want := make([]types.Page, len(tt.expected))
+			for i, text := range tt.expected {
+				want[i] = types.Page{Number: i + 1, Text: text}
+			}
+			assert.Equal(t, want, StripRepeatedHeadersFooters(input))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Attributes a **page number** to each chunk created from a PDF, stores it on the chunk, and surfaces it in the `sources` payload. PDF page numbers were already read during extraction but discarded the moment pages were joined into one string.

The core challenge: chunk offsets live in **normalized** coordinate space, and `Normalize` rewrites text non-linearly, so a page boundary measured in raw text won't map cleanly. The fix makes offsets and page spans share one coordinate system **by construction** — normalize per page and record cumulative offsets — so every span is exact, with no sentinel-marker tricks.

## What changed

- **PDF extraction** now yields `[]types.Page{Number, Text}` instead of a pre-joined string, preserving true (1-indexed) page numbers even when null/unextractable pages are skipped.
- **`StripRepeatedHeadersFooters`** returns cleaned per-page text (`[]string`) instead of a joined string. Header/footer detection still runs first on the full page slice.
- **`DocumentProcessor` owns normalization** and returns `ProcessedDocument{NormalizedText, PageSpans}`. The new `buildProcessedDocument` normalizes each cleaned page independently, concatenates with blank-line page breaks, and records exact `[]PageSpan{Page, Start, End}` over the final normalized text. Plain-text uploads carry `PageSpans == nil`.
- **`ProcessDocument`** consumes a `ProcessedDocument` (normalization moved out), and assigns each chunk's page by binary-searching its `StartOffset` into the spans. A chunk that straddles a page boundary is attributed to the page of its `StartOffset`.
- **Page surfacing:** adds `Page int` to `DocumentChunk` and writes `metadata["page"]` on a **per-chunk metadata clone** (the chunks previously shared one map reference — a naive write would have stamped every chunk with the last page). The frontend already declares `metadata.page?: number`, so this rides through with **no frontend change**.

## Design decisions

| Decision | Choice |
|---|---|
| Straddling chunk | Single `Page` = page of `StartOffset` |
| UI | Backend-only; threaded into `sources`, not rendered (consistent with the current "no source citations shown" design) |
| Per-page normalization | Accepted: a word hyphenated across a page seam (rare) won't rejoin; header/footer stripping is preserved |
| `ProcessDocument` signature | Normalization moved into the processor for exact-by-construction spans |

## Tests

- `TestBuildProcessedDocument` — multi-page contiguous spans, skipped/empty middle page (true page numbers preserved), single page, header/footer stripping before span computation, all-empty pages.
- `TestPageForOffset` — page starts, mid-span, the `\n\n` gap (→ preceding page), past-the-end, and nil spans.
- `TestProcessDocument_AttributesPageNumbers` — paginated doc stamps `Page` + `metadata["page"]` per chunk with **independent** metadata maps and an unmutated input map; plain-text doc stays unpaginated (`Page == 0`, no `metadata["page"]`).
- Updated all broken call sites (eval harness, `rag_pipeline`/`document_processor`/`upload` tests, normalizer test).

## Verification

```
go test ./...                                           # all green
go test ./internal/services/ -run TestEvalRetrieval -v  # ratchet gate
```

The retrieval eval gate is **unchanged** — `hit@1=0.737 recall@4=0.947 mrr=0.829` (thresholds 0.65/0.85/0.75). Its plain-text path uses whole-doc normalization with no spans, so chunking is byte-identical and page attribution touches neither embeddings nor ranking.

https://claude.ai/code/session_013qApXE6Qvhu83REznV3GqA

---
_Generated by [Claude Code](https://claude.ai/code/session_013qApXE6Qvhu83REznV3GqA)_